### PR TITLE
Fixed shell evaluation

### DIFF
--- a/shell/function/zeno-call-client-and-fallback
+++ b/shell/function/zeno-call-client-and-fallback
@@ -4,6 +4,7 @@ local mode=$1
 local input=$2
 
 if [[ -n $ZENO_ENABLE_SOCK ]]; then
+  (( $+functions[zeno-client] )) || zeno-enable-sock
   if [[ -S $ZENO_SOCK ]]; then
     zeno-client --zeno-mode=${mode} --input="${input}"
     return

--- a/shell/function/zeno-call-client-and-fallback
+++ b/shell/function/zeno-call-client-and-fallback
@@ -1,14 +1,11 @@
 #autoload
 
-local mode=$1
-local input=$2
-
 if [[ -n $ZENO_ENABLE_SOCK ]]; then
   (( $+functions[zeno-client] )) || zeno-enable-sock
   if [[ -S $ZENO_SOCK ]]; then
-    zeno-client --zeno-mode=${mode} --input="${input}"
+    zeno-client "$@"
     return
   fi
   zeno-start-server
 fi
-zeno --zeno-mode=${mode} --input="${input}"
+zeno "$@"

--- a/shell/function/zeno-enable-sock
+++ b/shell/function/zeno-enable-sock
@@ -21,8 +21,13 @@ function zeno-client() {
   isok=$?
   (( isok == 0 )) || return 1
   fd=$REPLY
-  args=('"'${^@//\"/\\\"}'"')
+  # send as JSON
+  args=( "${@//\\/\\\\}" )         # escape backslash
+  args=( "${(@)args//$'\n'/\\n}" ) # escape new-line
+  args=( "${(@)args//\"/\\\"}" )   # escape quote
+  args=( "\"${(@)^args}\"" )       # quote
   printf '{"args":[%s]}' "${(j:,:)args}" >&$fd
+  # receive result
   cat <&$fd
   exec {fd}>&-
 }

--- a/shell/snippet/widget/zeno-auto-snippet
+++ b/shell/snippet/widget/zeno-auto-snippet
@@ -6,7 +6,7 @@ local input
 local -a out
 
 input=$(printf '%s\n%s' "$LBUFFER" "$RBUFFER")
-out=( "${(f)$(zeno-call-client-and-fallback "auto-snippet" "$input")}" )
+out=( "${(f)$(zeno-call-client-and-fallback --zeno-mode=auto-snippet --input="$input")}" )
 
 if [[ $out[1] != success ]]; then
   LBUFFER+=" "

--- a/shell/snippet/widget/zeno-auto-snippet
+++ b/shell/snippet/widget/zeno-auto-snippet
@@ -1,23 +1,21 @@
 #autoload
 
-() {
-  emulate -L zsh
+emulate -L zsh
 
-  local input=$(printf '%s\n%s' "$LBUFFER" "$RBUFFER")
-  local out=$(zeno-call-client-and-fallback "auto-snippet" "$input")
+local input
+local -a out
 
-  if [[ $(echo "$out" | head -1) != "success" ]]; then
-    LBUFFER+=" "
-    return
-  fi
+input=$(printf '%s\n%s' "$LBUFFER" "$RBUFFER")
+out=( "${(f)$(zeno-call-client-and-fallback "auto-snippet" "$input")}" )
 
-  local buffer=$(echo "$out" | head -2 | tail -1)
-  local cursor=$(echo "$out" | head -3 | tail -1)
+if [[ $out[1] != success ]]; then
+  LBUFFER+=" "
+  return
+fi
 
-  if [[ $buffer != "" ]]; then
-    BUFFER=$buffer
-    CURSOR=$cursor
-  fi
+if [[ -n $out[2] ]]; then
+  BUFFER=$out[2]
+  CURSOR=$out[3]
+fi
 
-  zle reset-prompt
-}
+zle reset-prompt

--- a/shell/snippet/widget/zeno-auto-snippet-and-accept-line
+++ b/shell/snippet/widget/zeno-auto-snippet-and-accept-line
@@ -1,26 +1,19 @@
 #autoload
 
-() {
-  emulate -L zsh
+emulate -L zsh
 
-  local tokens=(${(z)LBUFFER})
+local input
+local -a out tokens
 
-  if [[ $#tokens != 1 ]]; then
-    zle accept-line
-    return
+tokens=( ${(z)LBUFFER} )
+
+if [[ $#tokens == 1 ]]; then
+  input="${LBUFFER}\n${RBUFFER}"
+  out=( "${(f)$(zeno-call-client-and-fallback 'auto-snippet' "$input")}" )
+
+  if [[ $out[1] == success && -n $out[2] ]]; then
+    BUFFER=$out[2]
   fi
+fi
 
-  local out=$(zeno-call-client-and-fallback "auto-snippet" "${LBUFFER}\n${RBUFFER}")
-
-  if [[ $(echo "$out" | head -1) != "success" ]]; then
-    zle accept-line
-    return
-  fi
-
-  local buffer=$(echo "$out" | head -2 | tail -1)
-
-  if [[ $buffer != "" ]]; then
-    BUFFER=$buffer
-    zle accept-line
-  fi
-}
+zle accept-line

--- a/shell/snippet/widget/zeno-auto-snippet-and-accept-line
+++ b/shell/snippet/widget/zeno-auto-snippet-and-accept-line
@@ -9,7 +9,7 @@ tokens=( ${(z)LBUFFER} )
 
 if [[ $#tokens == 1 ]]; then
   input=$(printf '%s\n%s' "$LBUFFER" "$RBUFFER")
-  out=( "${(f)$(zeno-call-client-and-fallback 'auto-snippet' "$input")}" )
+  out=( "${(f)$(zeno-call-client-and-fallback --zeno-mode=auto-snippet --input="$input")}" )
 
   if [[ $out[1] == success && -n $out[2] ]]; then
     BUFFER=$out[2]

--- a/shell/snippet/widget/zeno-auto-snippet-and-accept-line
+++ b/shell/snippet/widget/zeno-auto-snippet-and-accept-line
@@ -8,7 +8,7 @@ local -a out tokens
 tokens=( ${(z)LBUFFER} )
 
 if [[ $#tokens == 1 ]]; then
-  input="${LBUFFER}\n${RBUFFER}"
+  input=$(printf '%s\n%s' "$LBUFFER" "$RBUFFER")
   out=( "${(f)$(zeno-call-client-and-fallback 'auto-snippet' "$input")}" )
 
   if [[ $out[1] == success && -n $out[2] ]]; then

--- a/shell/snippet/widget/zeno-completion
+++ b/shell/snippet/widget/zeno-completion
@@ -1,35 +1,36 @@
 #autoload
 
-() {
-  emulate -L zsh
+emulate -L zsh
 
-  local completion=$(zeno-call-client-and-fallback "completion" "${LBUFFER}")
+local callback command key options source_command
+local -a out
 
-  if [[ $(echo "$completion" | head -1) != "success" ]]; then
-    if whence fzf-completion > /dev/null; then
-      zle fzf-completion
-      return
-    else
-      zle expand-or-complete
-      return
-    fi
+out=( "${(f)$(zeno-call-client-and-fallback "completion" "${LBUFFER}")}" )
+
+if [[ $out[1] != success ]]; then
+  if whence fzf-completion > /dev/null; then
+    zle fzf-completion
+  else
+    zle expand-or-complete
   fi
+  return
+fi
 
-  local source_command=$(echo "$completion" | head -2 | tail -1)
-  local options=$(echo "$completion" | head -3 | tail -1)
-  local callback=$(echo "$completion" | head -4 | tail -1 | tr '\n' ' ')
+source_command=$out[2]
+options=$out[3]
+callback=$out[4]
 
-  local trim_result="tr '\n' ' ' | sed 's/\s*$//'"
-  local command="${source_command} | ${ZENO_FZF_COMMAND} ${ZENO_FZF_TMUX_OPTIONS} ${options}"
+command="${source_command} | \"\${ZENO_FZF_COMMAND}\" ${ZENO_FZF_TMUX_OPTIONS} ${options}"
+out=( "${(f)$(eval $command)}" )
 
-  local out=$(eval $command)
-  local key=$(echo $out | head -1)
-  local lines=$(echo $out | sed -e '1d')
-  local result=$(echo $lines | eval ${callback} | eval ${trim_result})
+key=$out[1]
+shift out
 
-  LBUFFER+=$result
+if [[ -n $callback ]]; then
+  out=( "${(f)$(echo "${(F)out}" | eval $callback)}" )
+fi
 
-  zle zeno-snippet-next-placeholder
+LBUFFER+=$out
 
-  zle reset-prompt
-}
+zle zeno-snippet-next-placeholder
+zle reset-prompt

--- a/shell/snippet/widget/zeno-completion
+++ b/shell/snippet/widget/zeno-completion
@@ -2,7 +2,7 @@
 
 emulate -L zsh
 
-local callback command key options source_command
+local callback key options source_command
 local -a out
 
 out=( "${(f)$(zeno-call-client-and-fallback "completion" "${LBUFFER}")}" )
@@ -20,8 +20,10 @@ source_command=$out[2]
 options=$out[3]
 callback=$out[4]
 
-command="${source_command} | \"\${ZENO_FZF_COMMAND}\" ${ZENO_FZF_TMUX_OPTIONS} ${options}"
-out=( "${(f)$(eval $command)}" )
+options="${ZENO_ENABLE_FZF_TMUX:+${ZENO_FZF_TMUX_OPTIONS}} $options"
+out=(
+  "${(f)$(eval "${source_command} | ${ZENO_FZF_COMMAND} ${options}")}"
+)
 
 key=$out[1]
 shift out

--- a/shell/snippet/widget/zeno-completion
+++ b/shell/snippet/widget/zeno-completion
@@ -5,7 +5,7 @@ emulate -L zsh
 local callback key options source_command
 local -a out
 
-out=( "${(f)$(zeno-call-client-and-fallback "completion" "${LBUFFER}")}" )
+out=( "${(f)$(zeno-call-client-and-fallback --zeno-mode=completion --input="$LBUFFER")}" )
 
 if [[ $out[1] != success ]]; then
   if whence fzf-completion > /dev/null; then

--- a/shell/snippet/widget/zeno-ghq-cd
+++ b/shell/snippet/widget/zeno-ghq-cd
@@ -2,7 +2,7 @@
 
 emulate -L zsh
 
-local command current_session dir repository session
+local current_session dir options repository session
 local -a out
 
 out=( "${(f)^$(ghq list -p)}"(N-/) )
@@ -12,8 +12,10 @@ if [[ $#out == 0 ]]; then
   return 1
 fi
 
-command="\"\${ZENO_FZF_COMMAND}\" ${ZENO_FZF_TMUX_OPTIONS} --prompt='Project >' --preview 'cat \$(eval echo {})/README.md' --bind ctrl-d:preview-page-down,ctrl-u:preview-page-up"
-dir=$(echo "${(F)out}" | eval $command)
+options=${ZENO_ENABLE_FZF_TMUX:+${ZENO_FZF_TMUX_OPTIONS}}
+options+=" --prompt='Project >' --preview 'cat \$(eval echo {})/README.md'"
+options+=" --bind ctrl-d:preview-page-down,ctrl-u:preview-page-up"
+dir=$(echo "${(F)out}" | eval "${ZENO_FZF_COMMAND} $options")
 
 if [[ -z $dir ]]; then
   return 1

--- a/shell/snippet/widget/zeno-ghq-cd
+++ b/shell/snippet/widget/zeno-ghq-cd
@@ -1,28 +1,33 @@
 #autoload
 
-() {
-  emulate -L zsh
+emulate -L zsh
 
-  local project dir repository session current_session
-  dir=$(ghq list -p | sed -e "s|${HOME}|~|" | ${ZENO_FZF_COMMAND} ${ZENO_FZF_TMUX_OPTIONS} --prompt='Project >' --preview "cat \$(eval echo {})/README.md" --bind ctrl-d:preview-page-down,ctrl-u:preview-page-up)
+local command current_session dir repository session
+local -a out
 
-  if [[ $dir == "" ]]; then
-    return 1
+out=( "${(f)^$(ghq list -p)}"(N-/) )
+[[ -n $HOME ]] && out=( "${(@)out//#$HOME/~}" )
+
+if [[ $#out == 0 ]]; then
+  return 1
+fi
+
+command="\"\${ZENO_FZF_COMMAND}\" ${ZENO_FZF_TMUX_OPTIONS} --prompt='Project >' --preview 'cat \$(eval echo {})/README.md' --bind ctrl-d:preview-page-down,ctrl-u:preview-page-up"
+dir=$(echo "${(F)out}" | eval $command)
+
+if [[ -z $dir ]]; then
+  return 1
+fi
+
+BUFFER="cd ${dir// /\\ }"
+zle accept-line
+
+if [[ -n $TMUX ]]; then
+  repository=${dir:t}
+  session=${repository//./-}
+
+  current_session=$(tmux list-sessions | grep 'attached' | cut -d":" -f1)
+  if [[ $session -eq $current_session ]]; then
+    tmux rename-session "${session}"
   fi
-
-  if [[ ! -z ${TMUX} ]]; then
-    repository=${dir##*/}
-    session=${repository//./-}
-
-    BUFFER="cd ${dir}"
-    zle accept-line
-
-    current_session=$(tmux list-sessions | grep 'attached' | cut -d":" -f1)
-    if [[ $session -eq $current_session ]]; then
-      tmux rename-session "${session}"
-    fi
-  else
-    BUFFER="cd ${dir}"
-    zle accept-line
-  fi
-}
+fi

--- a/shell/snippet/widget/zeno-ghq-cd
+++ b/shell/snippet/widget/zeno-ghq-cd
@@ -27,9 +27,5 @@ zle accept-line
 if [[ -n $TMUX ]]; then
   repository=${dir:t}
   session=${repository//./-}
-
-  current_session=$(tmux list-sessions | grep 'attached' | cut -d":" -f1)
-  if [[ $session -eq $current_session ]]; then
-    tmux rename-session "${session}"
-  fi
+  tmux rename-session "${session}"
 fi

--- a/shell/snippet/widget/zeno-history-selection
+++ b/shell/snippet/widget/zeno-history-selection
@@ -2,10 +2,11 @@
 
 emulate -L zsh
 
-local command history
+local history options
 
-command="\"\${ZENO_FZF_COMMAND}\" ${ZENO_FZF_TMUX_OPTIONS} --no-sort --exact --query=\"\$LBUFFER\" --prompt='History> '"
-history=$(builtin history -n -r 1 | eval $command)
+options=${ZENO_ENABLE_FZF_TMUX:+${ZENO_FZF_TMUX_OPTIONS}}
+options+=" --no-sort --exact --query=\"\$LBUFFER\" --prompt='History> '"
+history=$(builtin history -n -r 1 | eval "${ZENO_FZF_COMMAND} $options")
 
 if [[ -n $history ]]; then
   BUFFER=$history

--- a/shell/snippet/widget/zeno-history-selection
+++ b/shell/snippet/widget/zeno-history-selection
@@ -1,12 +1,15 @@
 #autoload
 
-() {
-  emulate -L zsh
+emulate -L zsh
 
-  local history=$(\history -n -r 1 | ${ZENO_FZF_COMMAND} ${ZENO_FZF_TMUX_OPTIONS} --no-sort --exact --query="$LBUFFER" --prompt="History> ")
+local command history
 
-  if [[ $history != "" ]]; then
-    BUFFER=$history
-    CURSOR=$#BUFFER
-  fi
-}
+command="\"\${ZENO_FZF_COMMAND}\" ${ZENO_FZF_TMUX_OPTIONS} --no-sort --exact --query=\"\$LBUFFER\" --prompt='History> '"
+history=$(builtin history -n -r 1 | eval $command)
+
+if [[ -n $history ]]; then
+  BUFFER=$history
+  CURSOR=$#BUFFER
+fi
+
+zle reset-prompt

--- a/shell/snippet/widget/zeno-insert-snippet
+++ b/shell/snippet/widget/zeno-insert-snippet
@@ -2,7 +2,7 @@
 
 emulate -L zsh
 
-local command input lines options selected_snippet
+local input lines options selected_snippet
 local -a out
 
 out=( "${(f)$(zeno-call-client-and-fallback 'snippet-list')}" )
@@ -11,8 +11,8 @@ options=$out[1]
 shift out
 lines=${(F)out}
 
-command="\"\${ZENO_FZF_COMMAND}\" ${ZENO_FZF_TMUX_OPTIONS} ${options}"
-selected_snippet=$(echo "$lines" | eval $command)
+options="${ZENO_ENABLE_FZF_TMUX:+${ZENO_FZF_TMUX_OPTIONS}} $options"
+selected_snippet=$(echo "$lines" | eval "${ZENO_FZF_COMMAND} ${options}")
 
 input=$(printf '%s\n%s\n%s' "$selected_snippet" "$LBUFFER" "$RBUFFER")
 out=( "${(f)$(zeno-call-client-and-fallback 'insert-snippet' "$input")}" )

--- a/shell/snippet/widget/zeno-insert-snippet
+++ b/shell/snippet/widget/zeno-insert-snippet
@@ -1,30 +1,25 @@
 #autoload
 
-() {
-  emulate -L zsh
+emulate -L zsh
 
-  local out=$(zeno-call-client-and-fallback "snippet-list")
+local command input lines options selected_snippet
+local -a out
 
-  local options=$(echo "$out" | head -1)
+out=( "${(f)$(zeno-call-client-and-fallback 'snippet-list')}" )
 
-  local command="tail +2 | ${ZENO_FZF_COMMAND} ${ZENO_FZF_TMUX_OPTIONS} ${options}"
-  local selected_snippet=$(zeno-call-client-and-fallback "snippet-list" | eval $command)
+options=$out[1]
+shift out
+lines=${(F)out}
 
-  local input=$(printf '%s\n%s\n%s' "$selected_snippet" "$LBUFFER" "$RBUFFER")
-  local out=$(zeno-call-client-and-fallback "insert-snippet" "$input")
+command="\"\${ZENO_FZF_COMMAND}\" ${ZENO_FZF_TMUX_OPTIONS} ${options}"
+selected_snippet=$(echo "$lines" | eval $command)
 
-  if [[ $(echo "$out" | head -1) != "success" ]]; then
-    zle reset-prompt
-    return
-  fi
+input=$(printf '%s\n%s\n%s' "$selected_snippet" "$LBUFFER" "$RBUFFER")
+out=( "${(f)$(zeno-call-client-and-fallback 'insert-snippet' "$input")}" )
 
-  local buffer=$(echo "$out" | head -2 | tail -1)
-  local cursor=$(echo "$out" | head -3 | tail -1)
+if [[ $out[1] == success && -n $out[2] ]]; then
+  BUFFER=$out[2]
+  CURSOR=$out[3]
+fi
 
-  if [[ $buffer != "" ]]; then
-    BUFFER=$buffer
-    CURSOR=$cursor
-  fi
-
-  zle reset-prompt
-}
+zle reset-prompt

--- a/shell/snippet/widget/zeno-insert-snippet
+++ b/shell/snippet/widget/zeno-insert-snippet
@@ -5,7 +5,7 @@ emulate -L zsh
 local input lines options selected_snippet
 local -a out
 
-out=( "${(f)$(zeno-call-client-and-fallback 'snippet-list')}" )
+out=( "${(f)$(zeno-call-client-and-fallback --zeno-mode=snippet-list)}" )
 
 options=$out[1]
 shift out
@@ -15,7 +15,7 @@ options="${ZENO_ENABLE_FZF_TMUX:+${ZENO_FZF_TMUX_OPTIONS}} $options"
 selected_snippet=$(echo "$lines" | eval "${ZENO_FZF_COMMAND} ${options}")
 
 input=$(printf '%s\n%s\n%s' "$selected_snippet" "$LBUFFER" "$RBUFFER")
-out=( "${(f)$(zeno-call-client-and-fallback 'insert-snippet' "$input")}" )
+out=( "${(f)$(zeno-call-client-and-fallback --zeno-mode=insert-snippet --input="$input")}" )
 
 if [[ $out[1] == success && -n $out[2] ]]; then
   BUFFER=$out[2]

--- a/shell/snippet/widget/zeno-snippet-next-placeholder
+++ b/shell/snippet/widget/zeno-snippet-next-placeholder
@@ -1,19 +1,12 @@
 #autoload
 
-() {
-  emulate -L zsh
+emulate -L zsh
 
-  local out=$(zeno-call-client-and-fallback "next-placeholder" "${BUFFER}")
+local -a out
 
-  if [[ $(echo "$out" | head -1) != "success" ]]; then
-    return
-  fi
+out=( "${(f)$(zeno-call-client-and-fallback 'next-placeholder' "${BUFFER}")}" )
 
-  local buffer=$(echo "$out" | head -2 | tail -1)
-  local cursor=$(echo "$out" | head -3 | tail -1)
-
-  if [[ $buffer != "" ]]; then
-    BUFFER=$buffer
-    CURSOR=$cursor
-  fi
-}
+if [[ $out[1] == success && -n $out[2] ]]; then
+  BUFFER=$out[2]
+  CURSOR=$out[3]
+fi

--- a/shell/snippet/widget/zeno-snippet-next-placeholder
+++ b/shell/snippet/widget/zeno-snippet-next-placeholder
@@ -4,7 +4,7 @@ emulate -L zsh
 
 local -a out
 
-out=( "${(f)$(zeno-call-client-and-fallback 'next-placeholder' "${BUFFER}")}" )
+out=( "${(f)$(zeno-call-client-and-fallback --zeno-mode=next-placeholder --input="$BUFFER")}" )
 
 if [[ $out[1] == success && -n $out[2] ]]; then
   BUFFER=$out[2]

--- a/src/const/source.ts
+++ b/src/const/source.ts
@@ -1,9 +1,9 @@
 export const GIT_STATUS_SOURCE = "git -c color.status=always status --short";
 export const GIT_STATUS_CALLBACK =
-  "perl -nle '@arr=split(/ /,\$_); print @arr[\$#arr]'";
+  "awk '{ p = index($0, \"\\\"\"); if (p > 0) { $0 = substr($0, p) } else { $0 = $NF }; print }'";
 
 export const GIT_LS_FILES_SOURCE = "git ls-files";
-export const GIT_LS_FILES_CALLBACK = "awk '{ print \$1 }'";
+export const GIT_LS_FILES_CALLBACK = "awk '{ if (/ / && /^[^\"]/) { $0 = \"\\\"\" $0 \"\\\"\" }; print }'";
 
 export const GIT_LOG_SOURCE =
   "git log --decorate --color=always --format='%C(green)[commit]  %Creset%C(magenta)%h%Creset %C(yellow)%cr %x09%Creset [%C(blue)%an%Creset] %x09%C(auto)%s %d'";

--- a/src/const/source.ts
+++ b/src/const/source.ts
@@ -17,4 +17,4 @@ export const GIT_TAG_SOURCE =
 export const GIT_REFLOG_SOURCE =
   "git reflog --decorate --color=always --format='%C(green)[reflog]  %Creset%C(magenta)%h%Creset %C(yellow)%cr %x09%Creset [%C(blue)%an%Creset] %x09%C(auto)%s %d' 2> /dev/null";
 
-export const GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK = "awk '{ print \$2 }'";
+export const GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK = "awk '{ print $2 }'";

--- a/src/const/source.ts
+++ b/src/const/source.ts
@@ -1,9 +1,10 @@
 export const GIT_STATUS_SOURCE = "git -c color.status=always status --short";
 export const GIT_STATUS_CALLBACK =
-  "awk '{ p = index($0, \"\\\"\"); if (p > 0) { $0 = substr($0, p) } else { $0 = $NF }; print }'";
+  "perl -nle '($x, $_) = split(/.*? (?=\")|.* /, $_, 2); print'";
 
 export const GIT_LS_FILES_SOURCE = "git ls-files";
-export const GIT_LS_FILES_CALLBACK = "awk '{ if (/ / && /^[^\"]/) { $0 = \"\\\"\" $0 \"\\\"\" }; print }'";
+export const GIT_LS_FILES_CALLBACK =
+  "perl -nle 'if (/ / && /^[^\"]/) $_ = \"\\\"$_\\\"\"; print'";
 
 export const GIT_LOG_SOURCE =
   "git log --decorate --color=always --format='%C(green)[commit]  %Creset%C(magenta)%h%Creset %C(yellow)%cr %x09%Creset [%C(blue)%an%Creset] %x09%C(auto)%s %d'";


### PR DESCRIPTION
* Parsing results uses too many pipes and commands. So refactored with shell evaluation.
* Fixed to work correctly even if the result path contains spaces or quotes.
* Only used `$ZENO_FZF_TMUX_OPTIONS` when `$ZENO_ENABLE_FZF_TMUX` is set.