### PR TITLE
fixed parse input

### DIFF
--- a/shell/snippet/widget/zeno-auto-snippet
+++ b/shell/snippet/widget/zeno-auto-snippet
@@ -3,7 +3,8 @@
 () {
   emulate -L zsh
 
-  local out=$(zeno-call-client-and-fallback "auto-snippet" "${LBUFFER}\n${RBUFFER}")
+  local input=$(printf '%s\n%s' "$LBUFFER" "$RBUFFER")
+  local out=$(zeno-call-client-and-fallback "auto-snippet" "$input")
 
   if [[ $(echo "$out" | head -1) != "success" ]]; then
     LBUFFER+=" "

--- a/shell/snippet/widget/zeno-insert-snippet
+++ b/shell/snippet/widget/zeno-insert-snippet
@@ -6,19 +6,12 @@
   local out=$(zeno-call-client-and-fallback "snippet-list")
 
   local options=$(echo "$out" | head -1)
-  if [[ ! -z $ZENO_ENABLE_SOCK ]]; then
-    local command="zeno-client --zeno-mode=snippet-list | tail +2 | ${ZENO_FZF_COMMAND} ${ZENO_FZF_TMUX_OPTIONS} ${options}"
-  else
-    local command="zeno --zeno-mode=snippet-list | tail +2 | ${ZENO_FZF_COMMAND} ${ZENO_FZF_TMUX_OPTIONS} ${options}"
-  fi
 
-  local selected_snippet=$(eval $command)
+  local command="tail +2 | ${ZENO_FZF_COMMAND} ${ZENO_FZF_TMUX_OPTIONS} ${options}"
+  local selected_snippet=$(zeno-call-client-and-fallback "snippet-list" | eval $command)
 
-  if [[ ! -z $ZENO_ENABLE_SOCK ]]; then
-    local out=$(zeno-client "--zeno-mode=insert-snippet $selected_snippet\n$LBUFFER\n$RBUFFER")
-  else
-    local out=$(echo -n "$selected_snippet\n$LBUFFER\n$RBUFFER" | zeno --zeno-mode=insert-snippet)
-  fi
+  local input=$(printf '%s\n%s\n%s' "$selected_snippet" "$LBUFFER" "$RBUFFER")
+  local out=$(zeno-call-client-and-fallback "insert-snippet" "$input")
 
   if [[ $(echo "$out" | head -1) != "success" ]]; then
     zle reset-prompt

--- a/src/app.ts
+++ b/src/app.ts
@@ -165,9 +165,12 @@ const execCommand = async (
 const parseArgs = ({ args }: { args: Array<string> }) => {
   const parsedArgs = argsParser(args, argsParseOption) as Args;
   const mode = parsedArgs["zeno-mode"] ?? '';
-  const command = "-- " + (parsedArgs.input ?? '').replace(/\n$/, '');
-  const parsedCommand = argsParser(command, commandParseOption);
-  const input = parsedCommand._.join(" ") + (/\s$/.exec(command) ? " " : "");
+  const input = (parsedArgs.input ?? '').split("\n").map(line => {
+    const hasTrailingSpace = /\s$/.exec(line);
+    const command = `-- ${line}`;
+    const parsedCommand = argsParser(command, commandParseOption);
+    return parsedCommand._.join(" ") + (hasTrailingSpace ? " " : "");
+  }).join("\n");
   return { mode, input };
 };
 


### PR DESCRIPTION
Sorry bug in #44, auto-snippet does not work.

Fixed input argument and parse it.

* `\n` that in argument convert to real new-line in shell.
  (Before #44, `\n` is parsed to new-line at zsh's `echo` command)
* Normalize input line by line in typescript.