### PR TITLE
update depends and fix lint error

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { argsParser, iter, printf, sprintf } from "./deps.ts";
+import { argsParser, iterateReader, printf, sprintf } from "./deps.ts";
 import { autoSnippet } from "./snippet/auto-snippet.ts";
 import { insertSnippet } from "./snippet/insert-snippet.ts";
 import { snippetList, snippetListOptions } from "./snippet/snippet-list.ts";
@@ -164,8 +164,8 @@ const execCommand = async (
 
 const parseArgs = ({ args }: { args: Array<string> }) => {
   const parsedArgs = argsParser(args, argsParseOption) as Args;
-  const mode = parsedArgs["zeno-mode"] ?? '';
-  const input = (parsedArgs.input ?? '').split("\n").map(line => {
+  const mode = parsedArgs["zeno-mode"] ?? "";
+  const input = (parsedArgs.input ?? "").split("\n").map((line) => {
     const hasTrailingSpace = /\s$/.exec(line);
     const command = `-- ${line}`;
     const parsedCommand = argsParser(command, commandParseOption);
@@ -181,7 +181,7 @@ export const execServer = async ({ socketPath }: { socketPath: string }) => {
   });
 
   for await (const conn of listener) {
-    for await (const r of iter(conn)) {
+    for await (const r of iterateReader(conn)) {
       try {
         setConn(conn);
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,7 +1,7 @@
-export { existsSync } from "https://deno.land/std@0.94.0/fs/exists.ts";
-export { parse as yamlParse } from "https://deno.land/std@0.94.0/encoding/yaml.ts";
-export { printf, sprintf } from "https://deno.land/std@0.94.0/fmt/printf.ts";
-export { iter } from "https://deno.land/std@0.94.0/io/util.ts";
+export { existsSync } from "https://deno.land/std@0.113.0/fs/exists.ts";
+export { parse as yamlParse } from "https://deno.land/std@0.113.0/encoding/yaml.ts";
+export { printf, sprintf } from "https://deno.land/std@0.113.0/fmt/printf.ts";
+export { iterateReader } from "https://deno.land/std@0.113.0/streams/conversion.ts";
 // TODO: Use Deno.run https://deno.land/manual@v1.13.2/examples/subprocess
 export { exec, OutputMode } from "https://deno.land/x/exec@0.0.5/mod.ts";
 

--- a/src/snippet/auto-snippet.ts
+++ b/src/snippet/auto-snippet.ts
@@ -1,6 +1,5 @@
 import { loadSnippets } from "./settings.ts";
 import { exec, OutputMode } from "../deps.ts";
-import { Snippet } from "../type/settings.ts";
 
 type AutoSnippetData = {
   status: "success";


### PR DESCRIPTION
`iter` of `std/io/util.ts` is deprecated.

Use instead `iterateReader` of `std/streams/conversion.ts`