### PR TITLE
Fix input and output that splits by null (\0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,12 @@ snippets:
   - name: git status
     keyword: gs
     snippet: git status --short --branch
+
   # snippet with placeholder
   - name: git commit message
     keyword: gcim
     snippet: git commit -m '{{commit_message}}'
+
   - name: "null"
     keyword: "null"
     snippet: ">/dev/null 2>&1"
@@ -197,12 +199,14 @@ snippets:
       # buffer: '' 
       lbuffer: '.+\s'
       # rbuffer: ''
+
   - name: branch
     keyword: B
     snippet: git symbolic-ref --short HEAD
     context:
       lbuffer: '^git\s+checkout\s+'
     evaluate: true # eval snippet
+
 
 completions:
   - name: kill
@@ -213,6 +217,19 @@ completions:
       --multi: true
       --prompt: "'Kill Process> '"
     callback: "awk '{print $2}'"
+
+  # Use null (\0) termination Input / Output
+  - name: chdir
+    patterns:
+      - "^cd $"
+    sourceCommand: "find . -path '*/.git' -prune -o -maxdepth 5 -type d -print0"
+    options:
+      # Added --read0 if null termination is used in `sourceCommand` output.
+      --read0: true
+      --prompt: "'Chdir> '"
+      --preview: "cd {} && ls -a | sed '/^[.]*$/d'"
+    callback: "cut -z -c 3-"
+    callbackZero: true  # null termination is used in `callback` I/O
 ```
 
 ## Related project

--- a/shell/snippet/widget/zeno-completion
+++ b/shell/snippet/widget/zeno-completion
@@ -2,9 +2,10 @@
 
 emulate -L zsh
 
-local callback key options source_command
+local callback callback_zero cmdline expect_key options source_command
 local -a out
 
+# ${(f)...} : split by new-line (\n)
 out=( "${(f)$(zeno-call-client-and-fallback --zeno-mode=completion \
   --input.lbuffer="$LBUFFER" \
   --input.rbuffer="$RBUFFER" \
@@ -18,20 +19,40 @@ fi
 source_command=$out[2]
 options=$out[3]
 callback=$out[4]
+callback_zero=$out[5]
 
 options="${ZENO_ENABLE_FZF_TMUX:+${ZENO_FZF_TMUX_OPTIONS}} $options"
-out=(
-  "${(f)$(eval "${source_command} | ${ZENO_FZF_COMMAND} ${options}")}"
-)
+cmdline="${source_command} | ${ZENO_FZF_COMMAND} ${options}"
 
-key=$out[1]
+# ${(0)...} : split by null (\0)
+out=( "${(0)$(eval $cmdline)}" )
+
+expect_key=$out[1]
 shift out
 
-if [[ -n $callback ]]; then
-  out=( "${(f)$(echo "${(F)out}" | eval $callback)}" )
+# remove empty items
+out=( ${(@)out:#} )
+
+# filter output with callback
+if [[ $callback && $out ]]; then
+  if [[ $callback_zero ]]; then
+    # divide input and output by null (\0)
+    out=( "${(0)$(printf '%s\0' ${(@)out} | eval $callback)}" )
+  else
+    # divide input and output by new-line (\n)
+    out=( "${(f)$(printf '%s\n' ${(@)out} | eval $callback)}" )
+  fi
+
+  # remove empty items
+  out=( ${(@)out:#} )
 fi
 
-LBUFFER+=$out
+# update buffer if result is not empty
+if [[ $out ]]; then
+  # ${(@q)...} : quote each items
+  LBUFFER+=${(@q)out}
 
-zle zeno-snippet-next-placeholder
+  zle zeno-snippet-next-placeholder
+fi
+
 zle reset-prompt

--- a/src/app.ts
+++ b/src/app.ts
@@ -141,7 +141,11 @@ const execCommand = async ({
           format: "%s\n",
           text: fzfOptionsToString(source.options),
         });
-        await write({ format: "%s\n", text: source.callback });
+        await write({ format: "%s\n", text: source.callback ?? "" });
+        await write({
+          format: "%s\n",
+          text: source.callbackZero ? "zero" : "",
+        });
       } else {
         await write({ format: "%s\n", text: "failure" });
       }

--- a/src/completion/source/git.ts
+++ b/src/completion/source/git.ts
@@ -13,13 +13,12 @@ import {
   GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
   GIT_BRANCH_SOURCE,
   GIT_LOG_SOURCE,
-  GIT_LS_FILES_CALLBACK,
-  GIT_LS_FILES_SOURCE,
-  GIT_STASH_SOURCE,
-  GIT_STATUS_CALLBACK,
-  GIT_STATUS_SOURCE,
+  GIT_LS_FILES_SOURCE_0,
+  GIT_STASH_CALLBACK_0,
+  GIT_STASH_SOURCE_0,
+  GIT_STATUS_CALLBACK_0,
+  GIT_STATUS_SOURCE_0,
 } from "../../const/source.ts";
-import { ZENO_GIT_STASH_CUT } from "../../settings.ts";
 import type { CompletionSource } from "../../type/fzf.ts";
 
 export const gitSources: Array<CompletionSource> = [
@@ -29,27 +28,31 @@ export const gitSources: Array<CompletionSource> = [
       /^git add $/,
       /^git add( -p| --patch) $/,
     ],
-    sourceCommand: GIT_STATUS_SOURCE,
+    sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--multi": true,
       "--prompt": "'Git Add Files> '",
       "--preview": GIT_STATUS_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_STATUS_CALLBACK,
+    callback: GIT_STATUS_CALLBACK_0,
+    callbackZero: true,
   },
   {
     name: "git diff file",
     patterns: [
       /^git diff( ((-|--)\S+)*)? -- $/,
     ],
-    sourceCommand: GIT_STATUS_SOURCE,
+    sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Diff File> '",
       "--preview": GIT_STATUS_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_STATUS_CALLBACK,
+    callback: GIT_STATUS_CALLBACK_0,
+    callbackZero: true,
   },
   {
     name: "git diff branch file",
@@ -57,13 +60,13 @@ export const gitSources: Array<CompletionSource> = [
       /^git diff( ((-|--)\S+)*)?( \S+) -- $/,
       /^git diff( ((-|--)\S+)*)?( \S+)( \S+) -- $/,
     ],
-    sourceCommand: GIT_LS_FILES_SOURCE,
+    sourceCommand: GIT_LS_FILES_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Diff Branch File> '",
       "--preview": GIT_LS_FILES_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_LS_FILES_CALLBACK,
   },
   {
     name: "git diff",
@@ -110,29 +113,31 @@ export const gitSources: Array<CompletionSource> = [
     patterns: [
       /^git checkout -- $/,
     ],
-    sourceCommand: GIT_STATUS_SOURCE,
+    sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Checkout Files> '",
       "--multi": true,
       "--no-sort": true,
       "--preview": GIT_STATUS_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_STATUS_CALLBACK,
+    callback: GIT_STATUS_CALLBACK_0,
+    callbackZero: true,
   },
   {
     name: "git checkout branch files",
     patterns: [
       /^git checkout( \S+) -- $/,
     ],
-    sourceCommand: GIT_LS_FILES_SOURCE,
+    sourceCommand: GIT_LS_FILES_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Checkout Branch Files> '",
       "--multi": true,
       "--preview": GIT_LS_FILES_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_LS_FILES_CALLBACK,
   },
   {
     name: "git reset",
@@ -152,29 +157,31 @@ export const gitSources: Array<CompletionSource> = [
     patterns: [
       /^git reset -- $/,
     ],
-    sourceCommand: GIT_STATUS_SOURCE,
+    sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Reset Files> '",
       "--multi": true,
       "--no-sort": true,
       "--preview": GIT_STATUS_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_STATUS_CALLBACK,
+    callback: GIT_STATUS_CALLBACK_0,
+    callbackZero: true,
   },
   {
     name: "git reset branch files",
     patterns: [
       /^git reset( \S+) -- $/,
     ],
-    sourceCommand: GIT_LS_FILES_SOURCE,
+    sourceCommand: GIT_LS_FILES_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Reset Branch Files> '",
       "--multi": true,
       "--preview": GIT_LS_FILES_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_LS_FILES_CALLBACK,
   },
   {
     name: "git switch",
@@ -195,15 +202,17 @@ export const gitSources: Array<CompletionSource> = [
     patterns: [
       /^git restore $/,
     ],
-    sourceCommand: GIT_STATUS_SOURCE,
+    sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Restore> '",
       "--multi": true,
       "--no-sort": true,
       "--preview": GIT_STATUS_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_STATUS_CALLBACK,
+    callback: GIT_STATUS_CALLBACK_0,
+    callbackZero: true,
   },
   {
     name: "git restore target commit",
@@ -223,14 +232,14 @@ export const gitSources: Array<CompletionSource> = [
     patterns: [
       /^git restore( -s| --source) \S+ $/,
     ],
-    sourceCommand: GIT_LS_FILES_SOURCE,
+    sourceCommand: GIT_LS_FILES_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Restore Files> '",
       "--multi": true,
       "--preview": GIT_LS_FILES_PREVIEW,
+      "--read0": true,
     },
-    callback: GIT_LS_FILES_CALLBACK,
   },
   {
     name: "git rebase",
@@ -261,13 +270,14 @@ export const gitSources: Array<CompletionSource> = [
   {
     name: "git stash apply/drop/pop",
     patterns: [/git stash (apply|drop|pop)( ((-|--)\S+)*)?$/],
-    sourceCommand: GIT_STASH_SOURCE,
+    sourceCommand: GIT_STASH_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--prompt": "'Git Stash> '",
       "--preview": GIT_STASH_PREVIEW,
-      "--delimiter": ":",
+      "--read0": true,
     },
-    callback: ZENO_GIT_STASH_CUT,
+    callback: GIT_STASH_CALLBACK_0,
+    callbackZero: true,
   },
 ];

--- a/src/const/option.ts
+++ b/src/const/option.ts
@@ -42,18 +42,21 @@ const GIT_BRANCH_LOG_TAG_REFLOG_BIND: FzfOptionBinds = [
   },
 ];
 
-export const DEFAULT_OPTIONS: FzfOptions = {
+export const COMMON_OPTIONS: FzfOptions = {
   "--ansi": true,
-  "--bind": DEFAULT_BIND,
   "--expect": ["alt-enter"],
   "--height": "'80%'",
+  "--print0": true,
+};
+
+export const DEFAULT_OPTIONS: FzfOptions = {
+  ...COMMON_OPTIONS,
+  "--bind": DEFAULT_BIND,
 };
 
 export const GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS: FzfOptions = {
-  "--ansi": true,
+  ...COMMON_OPTIONS,
   "--bind": GIT_BRANCH_LOG_TAG_REFLOG_BIND,
-  "--expect": ["alt-enter"],
-  "--height": "'80%'",
   "--header": "'C-b: branch, C-c: commit, C-t: tag, C-r: reflog'",
   "--preview-window": "'down'",
 };

--- a/src/const/source.ts
+++ b/src/const/source.ts
@@ -1,10 +1,8 @@
-export const GIT_STATUS_SOURCE = "git -c color.status=always status --short";
-export const GIT_STATUS_CALLBACK =
-  "perl -nle '($x, $_) = split(/.*? (?=\")|.* /, $_, 2); print'";
+export const GIT_STATUS_SOURCE_0 =
+  "git -c color.status=always status --short -z";
+export const GIT_STATUS_CALLBACK_0 = "cut -z -c 4-";
 
-export const GIT_LS_FILES_SOURCE = "git ls-files";
-export const GIT_LS_FILES_CALLBACK =
-  'perl -nle \'if (/ / && /^[^"]/){ $_ = "\\"$_\\"" }; print\'';
+export const GIT_LS_FILES_SOURCE_0 = "git ls-files -z";
 
 export const GIT_LOG_SOURCE =
   "git log --decorate --color=always --format='%C(green)[commit]  %Creset%C(magenta)%h%Creset %C(yellow)%cr %x09%Creset [%C(blue)%an%Creset] %x09%C(auto)%s %d'";
@@ -20,4 +18,6 @@ export const GIT_REFLOG_SOURCE =
 
 export const GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK = "awk '{ print $2 }'";
 
-export const GIT_STASH_SOURCE = "git stash list";
+export const GIT_STASH_SOURCE_0 =
+  "git stash list --color=always --format='%C(magenta)%gd  %C(yellow)%cr %x09%C(auto)%gs' -z";
+export const GIT_STASH_CALLBACK_0 = "cut -z -d ' ' -f 1";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,8 +8,6 @@ export const ZENO_SOCK = Deno.env.get("ZENO_SOCK");
 
 export const ZENO_GIT_CAT = Deno.env.get("ZENO_GIT_CAT") ?? "cat";
 export const ZENO_GIT_TREE = Deno.env.get("ZENO_GIT_TREE") ?? "tree";
-export const ZENO_GIT_STASH_CUT = Deno.env.get("ZENO_GIT_STASH_CUT") ??
-  String.raw`sed 's/:.*//; s/[{}]/\\&/g'`;
 
 export const ZENO_DISABLE_BUILTIN_COMPLETION =
   Deno.env.get("ZENO_DISABLE_BUILTIN_COMPLETION") == null ? false : true;

--- a/src/type/fzf.ts
+++ b/src/type/fzf.ts
@@ -17,5 +17,6 @@ export type CompletionSource = {
   patterns: Array<RegExp>;
   sourceCommand: string;
   options: FzfOptions;
-  callback: string;
+  callback?: string;
+  callbackZero?: boolean;
 };

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -24,5 +24,6 @@ export type UserCompletionSource = {
   sourceCommand: string;
   preview: string;
   options: FzfOptions;
-  callback: string;
+  callback?: string;
+  callbackZero?: boolean;
 };


### PR DESCRIPTION
Changed to work correctly even if the file name contains line breaks.

## Overview

Use null `\0` termination stream for I/O.
Instead of newline `\n` termination.

## Changes

- Changed some source-commands to output with null termination.
  - eg. `git ls-files -z` (`-z` is null termination option)
  - Added `--read0` to some fzf-options.
  - Added `--print0` to common (**all**) fzf-options.
- Changed some callback to input and output with null termination.
  - eg. `cut -z -c 4-` (`-z` is null termination option)
  - The `callback` parameter is now optional, default is empty.
- Added `callbackZero` flag to completion-option.
  - This is a flag that tells callback to use null temination in I/O.
  - The `callbackZero` parameter is optional, default is false (empty).
- Removed `ZENO_GIT_STASH_CAT`.
  - This should be defined as const module.