### PR TITLE
Added `excludePatterns` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ snippets:
     # auto expand condition
     # If not defined, it is only valid at the beginning of a line.
     context:
-      # buffer: '' 
+      # buffer: ''
       lbuffer: '.+\s'
       # rbuffer: ''
 
@@ -209,10 +209,22 @@ snippets:
 
 
 completions:
-  - name: kill
-    patterns: 
-      - "^kill( -9)? $"
-    sourceCommand: "ps -ef | sed 1d"
+  # simple sourceCommand, no callback
+  - name: kill signal
+    patterns:
+      - "^kill -s $"
+    sourceCommand: "kill -l | tr ' ' '\\n'"
+    options:
+      --prompt: "'Kill Signal> '"
+
+  # use excludePatterns and callback
+  - name: kill pid
+    patterns:
+      - "^kill( .*)? $"
+    excludePatterns:
+      # -l, -n or -s is followed by SIGNAL instead of PID
+      - " -[lns] $"
+    sourceCommand: "LANG=C ps -ef | sed 1d"
     options:
       --multi: true
       --prompt: "'Kill Process> '"

--- a/src/completion/completion.ts
+++ b/src/completion/completion.ts
@@ -2,13 +2,12 @@ import { completionSources } from "./source/index.ts";
 import { normalizeCommand } from "../command.ts";
 import type { Input } from "../type/shell.ts";
 
-export const completion = (
-  input: Input,
-) => {
+export const completion = (input: Input) => {
   const lbuffer = normalizeCommand(input.lbuffer ?? "", {
     keepTrailingSpace: true,
   });
-  return completionSources.find((
-    source,
-  ) => (source.patterns.some((pattern) => pattern.exec(lbuffer) != null)));
+  return completionSources.find(({ patterns, excludePatterns }) => (
+    patterns.some((pattern) => pattern.test(lbuffer)) &&
+    !excludePatterns?.some((pattern) => pattern.test(lbuffer))
+  ));
 };

--- a/src/snippet/settings.ts
+++ b/src/snippet/settings.ts
@@ -10,16 +10,21 @@ export const loadSnippets = (): Array<Snippet> => {
 export const loadCompletions = (): Array<CompletionSource> => {
   const userCompletions = getSettings().completions;
 
-  let completions: Array<CompletionSource> = [];
-  for (const userCompletion of userCompletions) {
+  const completions = userCompletions.map((userCompletion) => {
     const bind = [
       ...DEFAULT_OPTIONS["--bind"] ?? [],
       ...userCompletion.options["--bind"] ?? [],
     ];
 
+    const [patterns, excludePatterns] = [
+      userCompletion.patterns,
+      userCompletion.excludePatterns,
+    ].map((patterns) => patterns?.map((pattern) => new RegExp(pattern)) ?? []);
+
     const completion: CompletionSource = {
       ...userCompletion,
-      patterns: userCompletion.patterns.map((pattern) => new RegExp(pattern)),
+      patterns,
+      excludePatterns,
       options: {
         ...DEFAULT_OPTIONS,
         ...userCompletion.options ?? {},
@@ -27,11 +32,8 @@ export const loadCompletions = (): Array<CompletionSource> => {
       },
     };
 
-    completions = [
-      ...completions,
-      completion,
-    ];
-  }
+    return completion;
+  });
 
   return completions;
 };

--- a/src/type/fzf.ts
+++ b/src/type/fzf.ts
@@ -15,6 +15,7 @@ export type FzfOptionBinds = Array<{
 export type CompletionSource = {
   name: string;
   patterns: Array<RegExp>;
+  excludePatterns?: Array<RegExp>;
   sourceCommand: string;
   options: FzfOptions;
   callback?: string;

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -21,6 +21,7 @@ export type Snippet = {
 export type UserCompletionSource = {
   name: string;
   patterns: Array<string>;
+  excludePatterns: Array<string>;
   sourceCommand: string;
   preview: string;
   options: FzfOptions;


### PR DESCRIPTION
It makes it easier to describe pattern matching.

eg.)
```yaml
completions:
  - name: kill pid
    patterns:
      - "^kill( .*)? $"
    excludePatterns:
      # -l, -n or -s is followed by SIGNAL instead of PID
      - " -[lns] $"
```