### PR TITLE
Fixed to unset ZENO_ENABLE_SOCK

### DIFF
--- a/zeno.zsh
+++ b/zeno.zsh
@@ -36,7 +36,7 @@ if [[ -n $ZENO_ENABLE_SOCK ]]; then
   if (( DENO_VERSION >= 11600 )); then
     zeno-enable-sock
   else
-    export ZENO_ENABLE_SOCK=0
+    unset ZENO_ENABLE_SOCK
   fi
 fi
 


### PR DESCRIPTION
ZENO_ENABLE_SOCK is checked empty or not in [zeno.zsh#L34](https://github.com/yuki-yano/zeno.zsh/blob/cda00339659d05098326e94764be34a7bea1ca23/zeno.zsh#L34).
Therefore, the automatic invalidation should be implemented by `unset`.