### PR TITLE
Improve git completions

### DIFF
--- a/src/completion/source/git.ts
+++ b/src/completion/source/git.ts
@@ -18,6 +18,7 @@ import {
   GIT_STASH_SOURCE_0,
   GIT_STATUS_CALLBACK_0,
   GIT_STATUS_SOURCE_0,
+  GIT_TAG_SOURCE,
 } from "../../const/source.ts";
 import type { CompletionSource } from "../../type/fzf.ts";
 
@@ -25,13 +26,13 @@ export const gitSources: readonly CompletionSource[] = [
   {
     name: "git add",
     patterns: [
-      /^git add $/,
-      /^git add( -p| --patch) $/,
+      /^git add(?: .*)? $/,
     ],
     sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
       "--multi": true,
+      "--no-sort": true,
       "--prompt": "'Git Add Files> '",
       "--preview": GIT_STATUS_PREVIEW,
       "--read0": true,
@@ -40,14 +41,20 @@ export const gitSources: readonly CompletionSource[] = [
     callbackZero: true,
   },
   {
-    name: "git diff file",
+    name: "git diff files",
     patterns: [
-      /^git diff( ((-|--)\S+)*)? -- $/,
+      /^git diff(?=.* -- ) .* $/,
+    ],
+    excludePatterns: [
+      /^git diff.* [^-].* -- /,
+      / --no-index /,
     ],
     sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
-      "--prompt": "'Git Diff File> '",
+      "--multi": true,
+      "--no-sort": true,
+      "--prompt": "'Git Diff Files> '",
       "--preview": GIT_STATUS_PREVIEW,
       "--read0": true,
     },
@@ -55,15 +62,16 @@ export const gitSources: readonly CompletionSource[] = [
     callbackZero: true,
   },
   {
-    name: "git diff branch file",
+    name: "git diff branch files",
     patterns: [
-      /^git diff( ((-|--)\S+)*)?( \S+) -- $/,
-      /^git diff( ((-|--)\S+)*)?( \S+)( \S+) -- $/,
+      /^git diff(?=.* -- ) .* $/,
+      /^git diff(?=.* --no-index ) .* $/,
     ],
     sourceCommand: GIT_LS_FILES_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
-      "--prompt": "'Git Diff Branch File> '",
+      "--multi": true,
+      "--prompt": "'Git Diff Branch Files> '",
       "--preview": GIT_LS_FILES_PREVIEW,
       "--read0": true,
     },
@@ -71,34 +79,82 @@ export const gitSources: readonly CompletionSource[] = [
   {
     name: "git diff",
     patterns: [
-      /^git diff( ((-|--)\S+)*)? $/,
-      /^git diff( ((-|--)\S+)*)?( \S+) $/,
+      /^git diff(?: .*)? $/,
     ],
     sourceCommand: GIT_BRANCH_SOURCE,
     options: {
       ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--multi": true,
       "--prompt": "'Git Diff> '",
       "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
     },
     callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
   },
   {
-    name: "git commit fixup",
-    patterns: [/^git commit (--fixup|--squash) $/],
+    name: "git commit",
+    patterns: [
+      /^git commit(?: .*)? -[cC] $/,
+      /^git commit(?: .*)? --fixup[= ](?:amend:|reword:)?$/,
+      /^git commit(?: .*)? --(?:(?:reuse|reedit)-message|squash)[= ]$/,
+    ],
+    excludePatterns: [
+      / -- /,
+    ],
     sourceCommand: GIT_LOG_SOURCE,
     options: {
       ...DEFAULT_OPTIONS,
-      "--prompt": "'Git Fixup> '",
+      "--prompt": "'Git Commit> '",
       "--no-sort": true,
       "--preview": GIT_LOG_PREVIEW,
     },
     callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
   },
   {
+    name: "git commit files",
+    patterns: [
+      /^git commit(?: .*)? $/,
+    ],
+    excludePatterns: [
+      / -[mF] $/,
+      / --(?:author|date|template|trailer) $/,
+    ],
+    sourceCommand: GIT_STATUS_SOURCE_0,
+    options: {
+      ...DEFAULT_OPTIONS,
+      "--multi": true,
+      "--no-sort": true,
+      "--preview": GIT_STATUS_PREVIEW,
+      "--prompt": "'Git Commit Files> '",
+      "--read0": true,
+    },
+    callback: GIT_STATUS_CALLBACK_0,
+    callbackZero: true,
+  },
+  {
+    name: "git checkout branch files",
+    patterns: [
+      /^git checkout(?=.*(?<! (?:-[bBt]|--orphan|--track|--conflict|--pathspec-from-file)) [^-]) .* $/,
+    ],
+    excludePatterns: [
+      / --(?:conflict|pathspec-from-file) $/,
+    ],
+    sourceCommand: GIT_LS_FILES_SOURCE_0,
+    options: {
+      ...DEFAULT_OPTIONS,
+      "--multi": true,
+      "--prompt": "'Git Checkout Branch Files> '",
+      "--preview": GIT_LS_FILES_PREVIEW,
+      "--read0": true,
+    },
+  },
+  {
     name: "git checkout",
     patterns: [
-      /^git checkout $/,
-      /^git checkout(( -t)|( --track)) $/,
+      /^git checkout(?: .*)? (?:--track=)?$/,
+    ],
+    excludePatterns: [
+      / -- /,
+      / --(?:conflict|pathspec-from-file) $/,
     ],
     sourceCommand: GIT_BRANCH_SOURCE,
     options: {
@@ -111,7 +167,10 @@ export const gitSources: readonly CompletionSource[] = [
   {
     name: "git checkout files",
     patterns: [
-      /^git checkout -- $/,
+      /^git checkout(?: .*)? $/,
+    ],
+    excludePatterns: [
+      / --(?:conflict|pathspec-from-file) $/,
     ],
     sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
@@ -126,14 +185,17 @@ export const gitSources: readonly CompletionSource[] = [
     callbackZero: true,
   },
   {
-    name: "git checkout branch files",
+    name: "git reset branch files",
     patterns: [
-      /^git checkout( \S+) -- $/,
+      /^git reset(?=.*(?<! --pathspec-from-file) [^-]) .* $/,
+    ],
+    excludePatterns: [
+      / --pathspec-from-file $/,
     ],
     sourceCommand: GIT_LS_FILES_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
-      "--prompt": "'Git Checkout Branch Files> '",
+      "--prompt": "'Git Reset Branch Files> '",
       "--multi": true,
       "--preview": GIT_LS_FILES_PREVIEW,
       "--read0": true,
@@ -142,7 +204,11 @@ export const gitSources: readonly CompletionSource[] = [
   {
     name: "git reset",
     patterns: [
-      /^git reset( --mixed| --soft| --hard)? $/,
+      /^git reset(?: .*)? $/,
+    ],
+    excludePatterns: [
+      / -- /,
+      / --pathspec-from-file $/,
     ],
     sourceCommand: GIT_LOG_SOURCE,
     options: {
@@ -155,7 +221,10 @@ export const gitSources: readonly CompletionSource[] = [
   {
     name: "git reset files",
     patterns: [
-      /^git reset -- $/,
+      /^git reset(?: .*)? $/,
+    ],
+    excludePatterns: [
+      / --pathspec-from-file $/,
     ],
     sourceCommand: GIT_STATUS_SOURCE_0,
     options: {
@@ -170,24 +239,9 @@ export const gitSources: readonly CompletionSource[] = [
     callbackZero: true,
   },
   {
-    name: "git reset branch files",
-    patterns: [
-      /^git reset( \S+) -- $/,
-    ],
-    sourceCommand: GIT_LS_FILES_SOURCE_0,
-    options: {
-      ...DEFAULT_OPTIONS,
-      "--prompt": "'Git Reset Branch Files> '",
-      "--multi": true,
-      "--preview": GIT_LS_FILES_PREVIEW,
-      "--read0": true,
-    },
-  },
-  {
     name: "git switch",
     patterns: [
-      /^git switch $/,
-      /^git switch(( -t)|( --track)) $/,
+      /^git switch(?: .*)? $/,
     ],
     sourceCommand: GIT_BRANCH_SOURCE,
     options: {
@@ -198,39 +252,25 @@ export const gitSources: readonly CompletionSource[] = [
     callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
   },
   {
-    name: "git restore",
+    name: "git restore source",
     patterns: [
-      /^git restore $/,
+      /^git restore(?: .*)? (?:-s |--source[= ])$/,
     ],
-    sourceCommand: GIT_STATUS_SOURCE_0,
-    options: {
-      ...DEFAULT_OPTIONS,
-      "--prompt": "'Git Restore> '",
-      "--multi": true,
-      "--no-sort": true,
-      "--preview": GIT_STATUS_PREVIEW,
-      "--read0": true,
-    },
-    callback: GIT_STATUS_CALLBACK_0,
-    callbackZero: true,
-  },
-  {
-    name: "git restore target commit",
-    patterns: [
-      /^git restore( -s| --source) $/,
+    excludePatterns: [
+      / -- /,
     ],
     sourceCommand: GIT_BRANCH_SOURCE,
     options: {
       ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
-      "--prompt": "'Git Restore Target Commit> '",
+      "--prompt": "'Git Restore Source> '",
       "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
     },
     callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
   },
   {
-    name: "git restore commit files",
+    name: "git restore source files",
     patterns: [
-      /^git restore( -s| --source) \S+ $/,
+      /^git restore(?=.* (?:-s |--source[= ])) .* $/,
     ],
     sourceCommand: GIT_LS_FILES_SOURCE_0,
     options: {
@@ -242,9 +282,43 @@ export const gitSources: readonly CompletionSource[] = [
     },
   },
   {
+    name: "git restore files",
+    patterns: [
+      /^git restore(?: .*)? $/,
+    ],
+    sourceCommand: GIT_STATUS_SOURCE_0,
+    options: {
+      ...DEFAULT_OPTIONS,
+      "--prompt": "'Git Restore Files> '",
+      "--multi": true,
+      "--no-sort": true,
+      "--preview": GIT_STATUS_PREVIEW,
+      "--read0": true,
+    },
+    callback: GIT_STATUS_CALLBACK_0,
+    callbackZero: true,
+  },
+  {
+    name: "git rebase branch",
+    patterns: [
+      /^git rebase(?=.*(?<! (?:-[xsX]|--exec|--strategy(?:-options)?|--onto)) [^-]) .* $/,
+    ],
+    sourceCommand: GIT_BRANCH_SOURCE,
+    options: {
+      ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--prompt": "'Git Rebase Branch> '",
+      "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
+    },
+    callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
+  },
+  {
     name: "git rebase",
     patterns: [
-      /git rebase( ((-|--)\S+)*)? $/,
+      /^git rebase(?: .*)? (?:--onto[= ])?$/,
+    ],
+    excludePatterns: [
+      / -[xsX] $/,
+      / --(?:exec|strategy(?:-option)?) $/,
     ],
     sourceCommand: GIT_LOG_SOURCE,
     options: {
@@ -255,9 +329,26 @@ export const gitSources: readonly CompletionSource[] = [
     callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
   },
   {
+    name: "git merge branch",
+    patterns: [
+      /^git merge(?: .*)? --into-name[= ]$/,
+    ],
+    sourceCommand: GIT_BRANCH_SOURCE,
+    options: {
+      ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--prompt": "'Git Merge Branch> '",
+      "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
+    },
+    callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
+  },
+  {
     name: "git merge",
     patterns: [
-      /git merge( ((-|--)\S+)*)? $/,
+      /git merge(?: .*)? $/,
+    ],
+    excludePatterns: [
+      / -[mFsX] $/,
+      / --(?:file|strategy(?:-option)?) $/,
     ],
     sourceCommand: GIT_LOG_SOURCE,
     options: {
@@ -268,8 +359,11 @@ export const gitSources: readonly CompletionSource[] = [
     callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
   },
   {
-    name: "git stash apply/drop/pop",
-    patterns: [/git stash (apply|drop|pop)( ((-|--)\S+)*)?$/],
+    name: "git stash",
+    patterns: [
+      /git stash (?:apply|drop|pop|show)(?: .*)? $/,
+      /git stash branch(?=.* [^-]) .* $/,
+    ],
     sourceCommand: GIT_STASH_SOURCE_0,
     options: {
       ...DEFAULT_OPTIONS,
@@ -279,5 +373,156 @@ export const gitSources: readonly CompletionSource[] = [
     },
     callback: GIT_STASH_CALLBACK_0,
     callbackZero: true,
+  },
+  {
+    name: "git stash branch",
+    patterns: [
+      /git stash branch(?: .*)? $/,
+    ],
+    sourceCommand: GIT_BRANCH_SOURCE,
+    options: {
+      ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--prompt": "'Git Stash Branch> '",
+      "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
+    },
+    callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
+  },
+  {
+    name: "git stash push files",
+    patterns: [
+      /git stash push(?: .*)? $/,
+    ],
+    sourceCommand: GIT_STATUS_SOURCE_0,
+    options: {
+      ...DEFAULT_OPTIONS,
+      "--multi": true,
+      "--no-sort": true,
+      "--prompt": "'Git Stash Push Files> '",
+      "--preview": GIT_STATUS_PREVIEW,
+      "--read0": true,
+    },
+    callback: GIT_STATUS_CALLBACK_0,
+    callbackZero: true,
+  },
+  {
+    name: "git log file",
+    patterns: [
+      /^git log(?=.* -- ) .* $/,
+    ],
+    sourceCommand: GIT_LS_FILES_SOURCE_0,
+    options: {
+      ...DEFAULT_OPTIONS,
+      "--prompt": "'Git Log File> '",
+      "--preview": GIT_LS_FILES_PREVIEW,
+      "--read0": true,
+    },
+  },
+  {
+    name: "git log",
+    patterns: [
+      /^git log(?: .*)? $/,
+    ],
+    excludePatterns: [
+      / --(?:skip|since|after|until|before|author|committer|date) $/,
+      / --(?:branches|tags|remotes|glob|exclude|pretty|format) $/,
+      / --grep(?:-reflog)? $/,
+      / --(?:min|max)-parents $/,
+    ],
+    sourceCommand: GIT_BRANCH_SOURCE,
+    options: {
+      ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--prompt": "'Git Log> '",
+      "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
+    },
+    callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
+  },
+  {
+    name: "git tag list commit",
+    patterns: [
+      /^git tag(?=.* (?:-l|--list) )(?: .*)? --(?:(?:no-)?(?:contains|merged)|points-at) $/,
+    ],
+    sourceCommand: GIT_LOG_SOURCE,
+    options: {
+      ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--prompt": "'Git Tag List Commit> '",
+      "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
+    },
+    callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
+  },
+  {
+    name: "git tag delete",
+    patterns: [
+      /^git tag(?=.* (?:-d|--delete) )(?: .*)? $/,
+    ],
+    sourceCommand: GIT_TAG_SOURCE,
+    options: {
+      ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--multi": true,
+      "--prompt": "'Git Tag Delete> '",
+      "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
+    },
+    callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
+  },
+  {
+    name: "git tag",
+    patterns: [
+      /^git tag(?: .*)? $/,
+    ],
+    excludePatterns: [
+      / -[umF] $/,
+      / --(?:local-user|format) $/,
+    ],
+    sourceCommand: GIT_TAG_SOURCE,
+    options: {
+      ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--prompt": "'Git Tag> '",
+      "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
+    },
+    callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
+  },
+  {
+    name: "git mv files",
+    patterns: [
+      /^git mv(?: .*)? $/,
+    ],
+    sourceCommand: GIT_LS_FILES_SOURCE_0,
+    options: {
+      ...DEFAULT_OPTIONS,
+      "--multi": true,
+      "--prompt": "'Git Mv Files> '",
+      "--preview": GIT_LS_FILES_PREVIEW,
+      "--read0": true,
+    },
+  },
+  {
+    name: "git rm files",
+    patterns: [
+      /^git rm(?: .*)? $/,
+    ],
+    sourceCommand: GIT_LS_FILES_SOURCE_0,
+    options: {
+      ...DEFAULT_OPTIONS,
+      "--multi": true,
+      "--prompt": "'Git Rm Files> '",
+      "--preview": GIT_LS_FILES_PREVIEW,
+      "--read0": true,
+    },
+  },
+  {
+    name: "git show",
+    patterns: [
+      /^git show(?: .*)? $/,
+    ],
+    excludePatterns: [
+      / --(?:pretty|format) $/,
+    ],
+    sourceCommand: GIT_LOG_SOURCE,
+    options: {
+      ...GIT_BRANCH_LOG_TAG_REFLOG_OPTIONS,
+      "--multi": true,
+      "--prompt": "'Git Show> '",
+      "--preview": GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW,
+    },
+    callback: GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK,
   },
 ];

--- a/src/const/preview.ts
+++ b/src/const/preview.ts
@@ -1,13 +1,27 @@
 import { ZENO_GIT_CAT, ZENO_GIT_TREE } from "../settings.ts";
 
-export const GIT_STATUS_PREVIEW =
-  `[[ \\$(git diff -- {-1}) ]] && git diff --color=always -- {-1} || [[ \\$(git diff --cached -- {-1} ) ]] && git diff --cached --color=always -- {-1} || ${ZENO_GIT_CAT} {-1} 2>/dev/null || ${ZENO_GIT_TREE} {-1} 2>/dev/null`;
+const git_log_pretty_format =
+  "format:%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]";
+
+export const GIT_STATUS_PREVIEW = `
+  ! git diff --exit-code --color=always -- {-1}
+  || ! git diff --exit-code --cached --color=always -- {-1}
+  || ${ZENO_GIT_CAT} {-1} 2>/dev/null
+  || ${ZENO_GIT_TREE} {-1} 2>/dev/null
+`.trim().replaceAll(/\n\s*/g, "");
 
 export const GIT_LS_FILES_PREVIEW = `${ZENO_GIT_CAT} {}`;
 
 export const GIT_LOG_PREVIEW = "git show --color=always {2}";
 
-export const GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW =
-  "[[ '{1}' == '[branch]' ]] && git log {2} --decorate --pretty='format:%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=iso --graph --color=always || [[ '{1}' == '[tag]' ]] && git log {2} --pretty='format:%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=iso --graph --color=always  || [[ '{1}' == '[commit]' ]] && git show --color=always {2} || [[ '{1}' == '[reflog]' ]] && git show --color=always {2}";
+export const GIT_BRANCH_LOG_TAG_REFLOG_PREVIEW = `
+  if [[ {1} == '[branch]' ]]; then
+    git log {2} --decorate --pretty='${git_log_pretty_format}' --date=iso --graph --color=always
+  elif [[ {1} == '[tag]' ]]; then
+    git log {2} --pretty='${git_log_pretty_format}' --date=iso --graph --color=always
+  elif [[ {1} == '[commit]' || {1} == '[reflog]' ]]; then
+    git show --color=always {2}
+  fi
+`.trim().replaceAll(/\n\s*/g, ";");
 
 export const GIT_STASH_PREVIEW = "git show --color=always {1}";

--- a/src/const/source.ts
+++ b/src/const/source.ts
@@ -1,3 +1,9 @@
+const git_log_format =
+  "%C(magenta)%h  %C(yellow)%cr %x09%C(blue)[%an] %x09%C(auto)%s %d";
+const git_for_each_ref_format =
+  "%(color:magenta)%(refname:short)  %(color:yellow)%(authordate:short) %09%(color:blue)[%(authorname)]%09";
+const git_stash_list_format = "%C(magenta)%gd  %C(yellow)%cr %x09%C(auto)%gs";
+
 export const GIT_STATUS_SOURCE_0 =
   "git -c color.status=always status --short -z";
 export const GIT_STATUS_CALLBACK_0 = "cut -z -c 4-";
@@ -5,19 +11,19 @@ export const GIT_STATUS_CALLBACK_0 = "cut -z -c 4-";
 export const GIT_LS_FILES_SOURCE_0 = "git ls-files -z";
 
 export const GIT_LOG_SOURCE =
-  "git log --decorate --color=always --format='%C(green)[commit]  %Creset%C(magenta)%h%Creset %C(yellow)%cr %x09%Creset [%C(blue)%an%Creset] %x09%C(auto)%s %d'";
+  `git log --decorate --color=always --format='%C(green)[commit] ${git_log_format}'`;
 
 export const GIT_BRANCH_SOURCE =
-  "git for-each-ref refs/heads refs/remotes --color=always --format='%(color:green)[branch]%09%(color:reset)%(color:magenta)%(refname:short)%(color:reset) %(color:yellow)%(authordate:short) %(color:reset) %(color:blue)[%(authorname)]%(color:reset)%09' 2> /dev/null | column -t";
+  `git for-each-ref refs/heads refs/remotes --color=always --format='%(color:green)[branch] ${git_for_each_ref_format}' 2> /dev/null | column -t`;
 
 export const GIT_TAG_SOURCE =
-  "git for-each-ref refs/tags --color=always --format='%(color:green)[tag]%09%(color:reset)%(color:magenta)%(refname:short)%(color:reset) %(color:yellow)%(authordate:short) %(color:reset) %(color:blue)[%(authorname)]%(color:reset)%09' 2> /dev/null | column -t";
+  `git for-each-ref refs/tags --color=always --format='%(color:green)[tag] ${git_for_each_ref_format}' 2> /dev/null | column -t`;
 
 export const GIT_REFLOG_SOURCE =
-  "git reflog --decorate --color=always --format='%C(green)[reflog]  %Creset%C(magenta)%h%Creset %C(yellow)%cr %x09%Creset [%C(blue)%an%Creset] %x09%C(auto)%s %d' 2> /dev/null";
+  `git reflog --decorate --color=always --format='%C(green)[reflog] ${git_log_format}' 2> /dev/null`;
 
 export const GIT_BRANCH_LOG_TAG_REFLOG_CALLBACK = "awk '{ print $2 }'";
 
 export const GIT_STASH_SOURCE_0 =
-  "git stash list --color=always --format='%C(magenta)%gd  %C(yellow)%cr %x09%C(auto)%gs' -z";
+  `git stash list --color=always --format='${git_stash_list_format}' -z`;
 export const GIT_STASH_CALLBACK_0 = "cut -z -d ' ' -f 1";


### PR DESCRIPTION
- Added these sub-commands completions
  - `stash branch`: comlete git-branch-source
  - `stash push`: complete git-stats-source, multi
  - `stash show`: complete git-stash-source
  - `log`: complete branches or files
  - `tag --list`: complete git-log-source
  - `tag --delete`: complete git-tag-source, multi
  - `tag`: complete git-tag-source
  - `mv`: complete git-ls-files-source, multi
  - `rm`: complete git-ls-files-source, multi
  - `show`: complete git-log-source, multi
- Fixed these sub-commands completions
  - `add`: fixed patterns, options
  - `diff`: fixed patterns, options
  - `commit`: fixed patterns, complete git-ls-files-source
  - `checkout`: fixed patterns
  - `reset`: fixed patterns
  - `switch`: fixed patterns
  - `restore`: fixed patterns
  - `rebase`: fixed patterns, complete git-branch-source
  - `merge`: fixed patterns, complete git-branch-source
  - `stash`: fixed patterns
- Fixed source and preview formats