### PR TITLE
disable generate `deno.lock` when new shell startup.

### DIFF
--- a/zeno.zsh
+++ b/zeno.zsh
@@ -28,7 +28,7 @@ else
 fi
 
 if [[ -z $ZENO_DISABLE_EXECUTE_CACHE_COMMAND ]]; then
-  command deno cache --unstable-byonm --no-check -- "${ZENO_ROOT}/src/cli.ts"
+  command deno cache --unstable-byonm --no-lock --no-check -- "${ZENO_ROOT}/src/cli.ts"
 fi
 
 if [[ -n $ZENO_ENABLE_SOCK ]]; then


### PR DESCRIPTION
## description

If you launch a new pane of wezterm in the directory where `package.json` exists or start a shell with vim's `:term`, `deno.lock` will be generated.
Therefore, we added the `--no-lock` option to prevent `deno.lock` from being generated.
