### PR TITLE
docs(readme): replace `exa` with `eza`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ export ZENO_GIT_CAT="cat"
 # default
 export ZENO_GIT_TREE="tree"
 # git folder preview with color
-# export ZENO_GIT_TREE="exa --tree"
+# export ZENO_GIT_TREE="eza --tree"
 
 if [[ -n $ZENO_LOADED ]]; then
   bindkey ' '  zeno-auto-snippet


### PR DESCRIPTION
Thank you for creating and maintaining fantastic tool! 🚀

zeno.zsh makes my development more efficient! 🥇

As you may know, [exa](https://github.com/ogham/exa) is no longer maintained. 
Instead of it, community fork called [eza](https://github.com/eza-community/eza) is used.

`--tree` option is fine as is because `eza --tree` is still valid command.
<img width="370" alt="image" src="https://github.com/user-attachments/assets/2dfc89ea-681e-4138-b30a-a7cac61ff9a5" />
