### PR TITLE
refactor: extract duplicate result handling code into helper functions

### DIFF
--- a/src/app-helpers.ts
+++ b/src/app-helpers.ts
@@ -1,0 +1,49 @@
+import type { write } from "./text-writer.ts";
+
+export type WriteFunction = typeof write;
+
+/**
+ * Write result status and optional data lines
+ */
+export const writeResult = async (
+  writeFn: WriteFunction,
+  status: "success" | "failure",
+  ...dataLines: string[]
+): Promise<void> => {
+  await writeFn({ format: "%s\n", text: status });
+  for (const data of dataLines) {
+    await writeFn({ format: "%s\n", text: data });
+  }
+};
+
+/**
+ * Handle result object with status property
+ */
+export const handleStatusResult = async <
+  T extends { status: "success" | "failure" },
+>(
+  writeFn: WriteFunction,
+  result: T,
+  getSuccessData: (result: T) => string[],
+): Promise<void> => {
+  if (result.status === "failure") {
+    await writeResult(writeFn, "failure");
+  } else if (result.status === "success") {
+    await writeResult(writeFn, "success", ...getSuccessData(result));
+  }
+};
+
+/**
+ * Handle nullable result
+ */
+export const handleNullableResult = async <T>(
+  writeFn: WriteFunction,
+  result: T | null | undefined,
+  getSuccessData: (result: T) => string[],
+): Promise<void> => {
+  if (result != null) {
+    await writeResult(writeFn, "success", ...getSuccessData(result));
+  } else {
+    await writeResult(writeFn, "failure");
+  }
+};

--- a/test/app-helpers_test.ts
+++ b/test/app-helpers_test.ts
@@ -1,0 +1,92 @@
+import { assertEquals } from "./deps.ts";
+import { write } from "../src/text-writer.ts";
+import {
+  handleNullableResult,
+  handleStatusResult,
+  writeResult,
+} from "../src/app-helpers.ts";
+
+// Mock write function for testing
+const createMockWriter = () => {
+  const output: string[] = [];
+  const mockWrite: typeof write = ({ format, text }) => {
+    output.push(format.replace("%s", text));
+    return Promise.resolve();
+  };
+  return { mockWrite, output };
+};
+
+Deno.test("writeResult - writes status and data lines", async () => {
+  const { mockWrite, output } = createMockWriter();
+
+  await writeResult(mockWrite, "success", "line1", "line2");
+
+  assertEquals(output, ["success\n", "line1\n", "line2\n"]);
+});
+
+Deno.test("writeResult - writes only status when no data", async () => {
+  const { mockWrite, output } = createMockWriter();
+
+  await writeResult(mockWrite, "failure");
+
+  assertEquals(output, ["failure\n"]);
+});
+
+Deno.test("handleStatusResult - handles success status", async () => {
+  const { mockWrite, output } = createMockWriter();
+  const result = {
+    status: "success" as const,
+    buffer: "test buffer",
+    cursor: 42,
+  };
+
+  await handleStatusResult(mockWrite, result, (r) => [
+    r.buffer,
+    r.cursor.toString(),
+  ]);
+
+  assertEquals(output, ["success\n", "test buffer\n", "42\n"]);
+});
+
+Deno.test("handleStatusResult - handles failure status", async () => {
+  const { mockWrite, output } = createMockWriter();
+  const result = { status: "failure" as const };
+
+  await handleStatusResult(mockWrite, result, () => []);
+
+  assertEquals(output, ["failure\n"]);
+});
+
+Deno.test("handleNullableResult - handles non-null result", async () => {
+  const { mockWrite, output } = createMockWriter();
+  const result = {
+    sourceCommand: "git status",
+    options: {},
+    callback: "echo",
+    callbackZero: true,
+  };
+
+  await handleNullableResult(mockWrite, result, (r) => [
+    r.sourceCommand,
+    r.callback ?? "",
+    r.callbackZero ? "zero" : "",
+  ]);
+
+  assertEquals(output, ["success\n", "git status\n", "echo\n", "zero\n"]);
+});
+
+Deno.test("handleNullableResult - handles null result", async () => {
+  const { mockWrite, output } = createMockWriter();
+
+  await handleNullableResult(mockWrite, null, () => []);
+
+  assertEquals(output, ["failure\n"]);
+});
+
+Deno.test("handleNullableResult - handles undefined result", async () => {
+  const { mockWrite, output } = createMockWriter();
+
+  await handleNullableResult(mockWrite, undefined, () => []);
+
+  assertEquals(output, ["failure\n"]);
+});


### PR DESCRIPTION
## Summary
- Extracted duplicate success/failure handling patterns into reusable helper functions
- Created app-helpers.ts module to centralize result handling logic
- Reduced code duplication across command handlers in app.ts

## Changes
- **app-helpers.ts**: New module with three helper functions:
  - `writeResult`: Write status and optional data lines
  - `handleStatusResult`: Handle objects with status property
  - `handleNullableResult`: Handle nullable results
- **app.ts**: Refactored all command handlers to use the new helpers
- **test/app-helpers_test.ts**: Added comprehensive unit tests for all helpers

## Benefits
- Eliminated repetitive code patterns
- Improved maintainability
- Consistent error handling across all commands
- Easier to add new commands with standard response patterns
- Better testability with isolated helper functions

## Test plan
- [x] Added unit tests for all helper functions
- [x] All existing tests pass
- [x] CI checks pass (format, lint, type-check)
- [x] No change in functionality - purely internal refactoring