### PR TITLE
Fix Fisher installation event names

### DIFF
--- a/conf.d/zeno.fish
+++ b/conf.d/zeno.fish
@@ -2,7 +2,7 @@
 # This file handles both Fisher installation and regular loading
 
 # Installation event handler
-function __zeno_install --on-event yuki-yano/zeno.zsh_install
+function __zeno_install --on-event zeno_install
     echo "Installing zeno.zsh..." >&2
     
     # Clone the full repository to a local directory
@@ -25,7 +25,7 @@ function __zeno_install --on-event yuki-yano/zeno.zsh_install
 end
 
 # Update event handler
-function __zeno_update --on-event yuki-yano/zeno.zsh_update
+function __zeno_update --on-event zeno_update
     if set -q ZENO_ROOT
         echo "Updating zeno.zsh..." >&2
         command git -C $ZENO_ROOT pull
@@ -34,7 +34,7 @@ function __zeno_update --on-event yuki-yano/zeno.zsh_update
 end
 
 # Uninstall event handler
-function __zeno_uninstall --on-event yuki-yano/zeno.zsh_uninstall
+function __zeno_uninstall --on-event zeno_uninstall
     echo "Uninstalling zeno.zsh..." >&2
     
     # Remove from fish_function_path
@@ -70,5 +70,7 @@ else
         if test -f $zeno_config
             source $zeno_config
         end
+    else
+        echo "zeno.zsh is not installed. Run '__zeno_install' to complete installation." >&2
     end
 end


### PR DESCRIPTION
## Summary
This PR fixes the Fisher installation issue where `fisher install yuki-yano/zeno.zsh` did not automatically clone the repository.

## Problem
Fisher emits events based on the conf.d filename, not the GitHub repository path. The current implementation was listening for incorrect event names:
- `yuki-yano/zeno.zsh_install` (incorrect)
- `zeno_install` (correct)

## Changes
- Fixed event names in `/conf.d/zeno.fish`:
  - `--on-event yuki-yano/zeno.zsh_install` → `--on-event zeno_install`
  - `--on-event yuki-yano/zeno.zsh_update` → `--on-event zeno_update`
  - `--on-event yuki-yano/zeno.zsh_uninstall` → `--on-event zeno_uninstall`
- Added helpful message when zeno.zsh is not installed

## Test plan
1. Uninstall any existing installation:
   ```fish
   fisher remove yuki-yano/zeno.zsh
   rm -rf ~/.local/share/zeno.zsh
   ```
2. Install with Fisher:
   ```fish
   fisher install yuki-yano/zeno.zsh
   ```
3. Verify that:
   - The repository is automatically cloned to `~/.local/share/zeno.zsh`
   - No error messages appear
   - The installation completes successfully

Fixes #88