### PR TITLE
Fix Fish manual installation source error

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ Fisher will automatically clone the full repository to `~/.local/share/zeno.zsh`
 #### Manual installation
 
 ```fish
-$ git clone https://github.com/yuki-yano/zeno.zsh.git
-$ echo "set -gx fish_function_path /path/to/zeno.zsh/shells/fish/functions \$fish_function_path" >> ~/.config/fish/config.fish
+$ git clone https://github.com/yuki-yano/zeno.zsh.git /path/to/zeno.zsh
+$ echo "set -gx ZENO_ROOT /path/to/zeno.zsh" >> ~/.config/fish/config.fish
 $ ln -s /path/to/zeno.zsh/shells/fish/conf.d/zeno.fish ~/.config/fish/conf.d/
 ```
+
+Note: Setting `ZENO_ROOT` explicitly is recommended for manual installations to avoid path resolution issues.
 
 ### Configuration for Fish
 


### PR DESCRIPTION
## Summary
This PR fixes the "source: missing filename argument" error that occurs during manual Fish installations with symlinks.

## Problem
When manually installing zeno.zsh with symlinks (as reported in Slack), users encountered:
```
source: missing filename argument or input redirection
```

This happened because:
1. The source command at line 93-96 tried to use `$ZENO_ROOT` when it could be undefined
2. Symlinked installations weren't properly resolved, causing path detection to fail

## Changes

### 1. Removed unnecessary source command
```diff
-# Force reload of zeno-enable-sock function before using it
-if test -f $ZENO_ROOT/shells/fish/functions/zeno-enable-sock.fish
-    source $ZENO_ROOT/shells/fish/functions/zeno-enable-sock.fish
-end
```
This was unnecessary because Fish automatically loads functions from `fish_function_path`.

### 2. Added safety checks for $ZENO_ROOT
All uses of `$ZENO_ROOT` now check if it's defined first:
```fish
if set -q ZENO_ROOT; and not contains $ZENO_ROOT/bin $PATH
```

### 3. Improved symlink resolution
```fish
set -l config_path (realpath (status --current-filename) 2>/dev/null; or status --current-filename)
```

### 4. Added helpful error message
When `ZENO_ROOT` cannot be determined, users now see:
```
Warning: ZENO_ROOT could not be determined. Please set it manually:
  set -gx ZENO_ROOT /path/to/zeno.zsh
```

### 5. Updated README for manual installations
Now recommends setting `ZENO_ROOT` explicitly to avoid issues.

## Test plan
1. Manual installation with symlinks:
   ```fish
   git clone https://github.com/yuki-yano/zeno.zsh.git ~/ghq/github.com/yuki-yano/zeno.zsh
   ln -s ~/ghq/github.com/yuki-yano/zeno.zsh/shells/fish/conf.d/zeno.fish ~/.config/fish/conf.d/
   ```
2. Verify no "source" errors occur
3. Test with explicit ZENO_ROOT:
   ```fish
   set -gx ZENO_ROOT ~/ghq/github.com/yuki-yano/zeno.zsh
   ```
4. Verify all functionality works correctly

## Related discussions
- Reported in project Slack channel
- Related to Fish manual installation documentation