### PR TITLE
fix(ci): fix molt command syntax error

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -16,7 +16,7 @@ jobs:
       
       - name: Update dependencies
         run: |
-          deno run --allow-env --allow-read --allow-write --allow-net --allow-run=git,deno jsr:@molt/cli update src/deps.ts test/deps.ts --write
+          deno run --allow-env --allow-read --allow-write --allow-net --allow-run=git,deno jsr:@molt/cli src/deps.ts test/deps.ts --write
       
       - name: Format updated files
         run: deno fmt src/deps.ts test/deps.ts


### PR DESCRIPTION
## Summary
Fix molt command syntax error by removing the non-existent 'update' subcommand.

## Problem
The workflow failed with:
```
error: Uncaught (in promise) NotFound: No such file or directory (os error 2): readfile 'update'
```

This happened because molt was trying to read 'update' as a file, since molt has no 'update' subcommand.

## Solution
Remove 'update' from the molt command. The correct syntax is:
```bash
molt src/deps.ts test/deps.ts --write
```

## Verification
Tested locally with:
```bash
deno run --allow-env --allow-read --allow-write --allow-net --allow-run=git,deno jsr:@molt/cli --help
```

The help output shows no 'update' subcommand. The usage is: `molt [source...]`