### PR TITLE
ci: update CI workflow to use latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,14 @@ jobs:
         runner:
           - ubuntu-latest
         version:
-          - "1.x"
+          - "2.x"
     runs-on: ${{ matrix.runner }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: denoland/setup-deno@v1
+    - uses: actions/checkout@v4
+    - uses: denoland/setup-deno@v2
       with:
         deno-version: "${{ matrix.version }}"
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ env.DENO_DIR }}
         key: ${{ runner.os }}-deno-${{ matrix.version }}-${{ hashFiles('**/*.ts') }}


### PR DESCRIPTION
## Summary
Update CI workflow to use the latest versions of Deno and GitHub Actions.

## Changes
- **Deno**: Update from 1.x to 2.x (matching the update-dependencies workflow)
- **GitHub Actions**:
  - `actions/checkout`: v3 → v4
  - `denoland/setup-deno`: v1 → v2
  - `actions/cache`: v3 → v4

## Motivation
- Keep CI consistent with the latest Deno version
- Use the latest GitHub Actions for better performance and security
- Align with the update-dependencies workflow which already uses these versions