### PR TITLE
docs: add JSDoc comments to main modules

### DIFF
--- a/src/app-factory.ts
+++ b/src/app-factory.ts
@@ -6,13 +6,34 @@ import { createSocketServer } from "./socket/server.ts";
 import type { CommandRegistry } from "./command/registry.ts";
 import type { ConnectionConfig } from "./socket/connection-manager.ts";
 
+/**
+ * Configuration options for creating an app instance
+ */
 export type AppConfig = {
+  /** Custom command registry for handling commands */
   commandRegistry?: CommandRegistry;
+  /** Configuration for socket connection management */
   connectionConfig?: ConnectionConfig;
 };
 
 /**
  * Factory for creating app instances with dependency injection
+ *
+ * @param config - Configuration options for the app
+ * @param config.commandRegistry - Optional custom command registry. If not provided, uses the default registry
+ * @param config.connectionConfig - Optional connection configuration for socket server
+ * @returns App instance with execCli and execServer methods
+ *
+ * @example
+ * ```ts
+ * // Create app with default configuration
+ * const app = createApp();
+ *
+ * // Create app with custom command registry
+ * const customApp = createApp({
+ *   commandRegistry: myCustomRegistry
+ * });
+ * ```
  */
 export const createApp = (config: AppConfig = {}) => {
   // Use provided registry or create default one
@@ -21,7 +42,9 @@ export const createApp = (config: AppConfig = {}) => {
 
   return {
     /**
-     * Execute in CLI mode
+     * Execute zeno in CLI mode
+     * @param args - Command line arguments to parse and execute
+     * @throws Will exit process with code 1 on error
      */
     async execCli(args: Array<string>): Promise<void> {
       let res = 0;
@@ -39,7 +62,9 @@ export const createApp = (config: AppConfig = {}) => {
     },
 
     /**
-     * Execute as socket server
+     * Execute zeno as a Unix socket server
+     * @param socketPath - Path to the Unix socket file
+     * @throws Will throw if socket creation fails
      */
     async execServer(socketPath: string): Promise<void> {
       const server = createSocketServer({

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,10 +3,28 @@ import { createApp } from "./app-factory.ts";
 // Create default app instance for backward compatibility
 const app = createApp();
 
+/**
+ * Execute zeno in server mode, listening on a Unix socket
+ * @param params - Server execution parameters
+ * @param params.socketPath - Path to the Unix socket file
+ * @example
+ * ```ts
+ * await execServer({ socketPath: "/tmp/zeno.sock" });
+ * ```
+ */
 export const execServer = async ({ socketPath }: { socketPath: string }) => {
   await app.execServer(socketPath);
 };
 
+/**
+ * Execute zeno in CLI mode with command line arguments
+ * @param params - CLI execution parameters
+ * @param params.args - Command line arguments to parse
+ * @example
+ * ```ts
+ * await execCli({ args: ["--zeno-mode", "snippet-list"] });
+ * ```
+ */
 export const execCli = async ({ args }: { args: Array<string> }) => {
   await app.execCli(args);
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,11 @@
+/**
+ * @module cli
+ * Main CLI entry point for zeno
+ *
+ * This file is the entry point when running zeno from the command line.
+ * It parses command line arguments and executes the appropriate command.
+ */
+
 import { execCli } from "./app.ts";
 
 execCli({ args: Deno.args });

--- a/src/command/executor.ts
+++ b/src/command/executor.ts
@@ -26,7 +26,18 @@ const argsParseOption: Readonly<Partial<ArgParserOptions>> = {
 };
 
 /**
- * Parse command line arguments
+ * Parse command line arguments for zeno
+ *
+ * @param args - Command line arguments to parse
+ * @returns Parsed mode and input object
+ *
+ * @example
+ * ```ts
+ * const { mode, input } = parseArgs([
+ *   "--zeno-mode", "snippet-list",
+ *   "--input", '{"lbuffer": "git "}'
+ * ]);
+ * ```
  */
 export const parseArgs = (args: readonly string[]) => {
   const parsedArgs = argsParser([...args], argsParseOption) as Readonly<Args>;
@@ -52,6 +63,20 @@ export const parseArgs = (args: readonly string[]) => {
 
 /**
  * Create a command executor with the given registry
+ *
+ * @param registry - Command registry containing available commands
+ * @returns Async function that executes commands based on mode
+ *
+ * @example
+ * ```ts
+ * const registry = createCommandRegistry();
+ * const executor = createCommandExecutor(registry);
+ * await executor({
+ *   mode: "snippet-list",
+ *   input: { lbuffer: "git " },
+ *   writer: new TextWriter()
+ * });
+ * ```
  */
 export const createCommandExecutor = (registry: CommandRegistry) => {
   return async (context: CommandContext & { mode: string }) => {

--- a/src/command/registry.ts
+++ b/src/command/registry.ts
@@ -1,12 +1,32 @@
 import type { Command } from "./types.ts";
 
 /**
- * Create a command registry using closure
+ * Create a command registry for managing available commands
+ *
+ * The registry provides methods to register, retrieve, and query commands.
+ * Commands are identified by their unique name.
+ *
+ * @returns Command registry object with register, get, has, and list methods
+ *
+ * @example
+ * ```ts
+ * const registry = createCommandRegistry();
+ * registry.register({
+ *   name: "my-command",
+ *   execute: async (context) => { ... }
+ * });
+ * const command = registry.get("my-command");
+ * ```
  */
 export const createCommandRegistry = () => {
   const commands = new Map<string, Command>();
 
   return {
+    /**
+     * Register a new command
+     * @param command - Command to register
+     * @throws Error if a command with the same name is already registered
+     */
     register: (command: Command): void => {
       if (commands.has(command.name)) {
         throw new Error(`Command "${command.name}" is already registered`);
@@ -14,14 +34,28 @@ export const createCommandRegistry = () => {
       commands.set(command.name, command);
     },
 
+    /**
+     * Get a command by name
+     * @param name - Command name
+     * @returns Command if found, undefined otherwise
+     */
     get: (name: string): Command | undefined => {
       return commands.get(name);
     },
 
+    /**
+     * Check if a command exists
+     * @param name - Command name
+     * @returns true if command exists, false otherwise
+     */
     has: (name: string): boolean => {
       return commands.has(name);
     },
 
+    /**
+     * List all registered command names
+     * @returns Array of command names
+     */
     list: (): string[] => {
       return Array.from(commands.keys());
     },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,14 +19,25 @@ export {
 import { getConfigManager } from "./manager.ts";
 import type { Settings } from "../type/settings.ts";
 
+/**
+ * Get the current zeno settings
+ * @returns Promise resolving to the current settings
+ */
 export const getSettings = (): Promise<Settings> => {
   return getConfigManager().getSettings();
 };
 
+/**
+ * Update the zeno settings
+ * @param settings - New settings to apply
+ */
 export const setSettings = (settings: Settings): void => {
   getConfigManager().setSettings(settings);
 };
 
+/**
+ * Clear the settings cache, forcing a reload on next access
+ */
 export const clearCache = (): void => {
   getConfigManager().clearCache();
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,16 @@
+/**
+ * @module server
+ * Unix socket server entry point for zeno
+ *
+ * This file starts a Unix socket server that listens for commands from shell functions.
+ * It provides faster execution than CLI mode by keeping the process running.
+ *
+ * The server:
+ * - Listens on the socket path specified by ZENO_SOCK environment variable
+ * - Handles graceful shutdown on SIGINT, SIGTERM, and SIGHUP signals
+ * - Cleans up the socket file on exit
+ */
+
 import { execServer } from "./app.ts";
 import { exists, printf } from "./deps.ts";
 import { getEnv } from "./config/env.ts";
@@ -10,6 +23,10 @@ if (socketPath == null) {
   Deno.exit(1);
 }
 
+/**
+ * Signal handler for graceful shutdown
+ * Removes the socket file and exits the process
+ */
 const signalHandler = () => {
   Deno.removeSync(socketPath);
   Deno.exit(0);

--- a/src/snippet/auto-snippet.ts
+++ b/src/snippet/auto-snippet.ts
@@ -3,6 +3,9 @@ import { normalizeCommand, parseCommand } from "../command.ts";
 import { executeCommand } from "../util/exec.ts";
 import type { Input } from "../type/shell.ts";
 
+/**
+ * Result of auto-snippet expansion
+ */
 export type AutoSnippetData = {
   status: "success";
   buffer: string;
@@ -13,11 +16,27 @@ export type AutoSnippetData = {
   cursor?: undefined;
 };
 
+/**
+ * Check if the buffer matches the given context pattern
+ * @param buffer - The current command buffer
+ * @param context - Regular expression pattern to match against
+ * @returns true if the buffer matches the context
+ */
 const matchContext = (buffer: string, context: string): boolean => {
   const bufferRegex = new RegExp(context);
   return bufferRegex.test(buffer);
 };
 
+/**
+ * Automatically expand snippets based on the current buffer content
+ *
+ * This function checks if the current command line matches any snippet patterns
+ * and expands them accordingly. It supports context-aware snippets and command
+ * evaluation.
+ *
+ * @param input - Shell input containing lbuffer and rbuffer
+ * @returns Expanded buffer with new cursor position, or failure status
+ */
 export const autoSnippet = async (
   input: Input,
 ): Promise<AutoSnippetData> => {

--- a/src/socket/server.ts
+++ b/src/socket/server.ts
@@ -5,7 +5,25 @@ import { createConnectionManager } from "./connection-manager.ts";
 import type { SocketServerConfig } from "./types.ts";
 
 /**
- * Creates a socket server with the provided handler
+ * Creates a Unix socket server that listens for client connections
+ *
+ * @param config - Server configuration
+ * @param config.socketPath - Path to the Unix socket file
+ * @param config.handler - Function to handle incoming requests
+ * @param config.onError - Optional error handler
+ * @param config.connectionConfig - Optional connection management configuration
+ * @returns Server object with start and stop methods
+ *
+ * @example
+ * ```ts
+ * const server = createSocketServer({
+ *   socketPath: "/tmp/zeno.sock",
+ *   handler: async ({ args, writer }) => {
+ *     await writer.write({ format: "%s\n", text: "Hello" });
+ *   }
+ * });
+ * await server.start();
+ * ```
  */
 export const createSocketServer = (config: SocketServerConfig) => {
   const { socketPath, handler, onError, connectionConfig } = config;

--- a/src/text-writer.ts
+++ b/src/text-writer.ts
@@ -1,5 +1,11 @@
 import { sprintf } from "./deps.ts";
 
+/**
+ * TextWriter handles writing formatted text output to either a socket connection or stdout
+ *
+ * This class provides a unified interface for writing output that can be directed
+ * to either a Deno connection (when in socket mode) or standard output (when in CLI mode).
+ */
 export class TextWriter {
   private textEncoder: TextEncoder;
   private conn: Deno.Conn | undefined;
@@ -8,10 +14,19 @@ export class TextWriter {
     this.textEncoder = new TextEncoder();
   }
 
+  /**
+   * Set the connection to write to
+   * @param newConn - The Deno connection to use for output
+   */
   setConn(newConn: Deno.Conn): void {
     this.conn = newConn;
   }
 
+  /**
+   * Get the current connection
+   * @returns The current Deno connection
+   * @throws Error if no connection is set
+   */
   getConn(): Deno.Conn {
     if (this.conn === undefined) {
       throw new Error("Conn is not set");
@@ -19,14 +34,27 @@ export class TextWriter {
     return this.conn;
   }
 
+  /**
+   * Check if a connection is set
+   * @returns true if a connection is set, false otherwise
+   */
   hasConn(): boolean {
     return this.conn !== undefined;
   }
 
+  /**
+   * Clear the current connection
+   */
   clearConn(): void {
     this.conn = undefined;
   }
 
+  /**
+   * Write formatted text to the output
+   * @param params - Write parameters
+   * @param params.format - sprintf-style format string
+   * @param params.text - Text to format and write
+   */
   async write(
     { format, text }: { format: string; text: string },
   ): Promise<void> {
@@ -47,11 +75,38 @@ export class TextWriter {
 export const defaultWriter = new TextWriter();
 
 // Export functions for backward compatibility
+
+/**
+ * Set the connection for the default writer
+ * @param newConn - The Deno connection to use for output
+ */
 export const setConn = (newConn: Deno.Conn): void =>
   defaultWriter.setConn(newConn);
+
+/**
+ * Get the current connection from the default writer
+ * @returns The current Deno connection
+ * @throws Error if no connection is set
+ */
 export const getConn = (): Deno.Conn => defaultWriter.getConn();
+
+/**
+ * Check if the default writer has a connection
+ * @returns true if a connection is set, false otherwise
+ */
 export const hasConn = (): boolean => defaultWriter.hasConn();
+
+/**
+ * Clear the connection from the default writer
+ */
 export const clearConn = (): void => defaultWriter.clearConn();
+
+/**
+ * Write formatted text using the default writer
+ * @param params - Write parameters
+ * @param params.format - sprintf-style format string
+ * @param params.text - Text to format and write
+ */
 export const write = (
   { format, text }: { format: string; text: string },
 ): Promise<void> => defaultWriter.write({ format, text });


### PR DESCRIPTION
## Summary
- Added comprehensive JSDoc documentation to improve code understanding and maintainability
- Documented main entry points, core utilities, and key modules

## Changes
- **Entry points**: Added module-level and function documentation to `app.ts`, `cli.ts`, `server.ts`
- **Core utilities**: Documented `app-factory.ts` and `text-writer.ts` with detailed parameter descriptions
- **Command system**: Added JSDoc to `executor.ts` and `registry.ts` with usage examples
- **Socket server**: Documented the `createSocketServer` function with configuration details
- **Snippet functionality**: Added documentation to `auto-snippet.ts` explaining the expansion logic
- **Config module**: Documented convenience functions in `config/index.ts`

## Test plan
- [x] All existing tests pass (`make ci`)
- [x] Code formatting applied (`make fmt`)
- [x] Type checking passes
- [x] Linting passes