### PR TITLE
fix: handle numeric values in fzf option conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.claude
-ai
-log
-tmp
+/.claude
+/ai
+/log
+/tmp

--- a/src/fzf/option/convert.ts
+++ b/src/fzf/option/convert.ts
@@ -36,14 +36,18 @@ const generalOptionsToArray = (options: FzfOptions) => {
     .map(([key, value]) => {
       if (typeof value === "string") {
         return `${key}=${value}`;
+      } else if (typeof value === "number") {
+        return `${key}=${value}`;
       } else if (typeof value === "boolean") {
         if (value) {
           return key;
         }
+        return undefined;
       } else {
         return key;
       }
-    });
+    })
+    .filter((option): option is string => option !== undefined);
 };
 
 const optionsToArray = (options: FzfOptions) => {

--- a/src/fzf/option/convert.ts
+++ b/src/fzf/option/convert.ts
@@ -34,9 +34,7 @@ const generalOptionsToArray = (options: FzfOptions) => {
       !(CONVERT_IMPLEMENTED_OPTIONS as readonly string[]).includes(key)
     )
     .map(([key, value]) => {
-      if (typeof value === "string") {
-        return `${key}=${value}`;
-      } else if (typeof value === "number") {
+      if (typeof value === "string" || typeof value === "number") {
         return `${key}=${value}`;
       } else if (typeof value === "boolean") {
         if (value) {

--- a/test/fzf_option_convert_test.ts
+++ b/test/fzf_option_convert_test.ts
@@ -1,0 +1,79 @@
+import { assertEquals, describe, it } from "./deps.ts";
+import { fzfOptionsToString } from "../src/fzf/option/convert.ts";
+import type { FzfOptions } from "../src/type/fzf.ts";
+
+describe("fzf option convert", () => {
+  describe("fzfOptionsToString", () => {
+    it("handles string values correctly", () => {
+      const options: FzfOptions = {
+        "--header-lines": "2",
+        "--height": "80%",
+      };
+
+      const result = fzfOptionsToString(options);
+
+      // The function always adds --expect="alt-enter" by default
+      assertEquals(
+        result,
+        '--expect="alt-enter" --header-lines=2 --height=80%',
+      );
+    });
+
+    it("handles number values correctly", () => {
+      const options: FzfOptions = {
+        "--header-lines": 2 as unknown as string,
+        "--height": 80 as unknown as string,
+      };
+
+      const result = fzfOptionsToString(options);
+
+      // Now with the fix, numbers should be handled correctly
+      assertEquals(result, '--expect="alt-enter" --header-lines=2 --height=80');
+    });
+
+    it("handles boolean values correctly", () => {
+      const options: FzfOptions = {
+        "--multi": true,
+        "--ansi": true,
+        "--disabled": false as unknown as true,
+      };
+
+      const result = fzfOptionsToString(options);
+
+      assertEquals(result, '--expect="alt-enter" --multi --ansi');
+    });
+
+    it("handles mixed types", () => {
+      const options: FzfOptions = {
+        "--header": "Results",
+        "--header-lines": 2 as unknown as string,
+        "--multi": true,
+        "--preview": "echo {}",
+      };
+
+      const result = fzfOptionsToString(options);
+
+      // Should include all options properly formatted
+      assertEquals(result.includes('--preview="echo {}"'), true);
+      assertEquals(result.includes("--header=Results"), true);
+      assertEquals(result.includes("--header-lines=2"), true);
+      assertEquals(result.includes("--multi"), true);
+      assertEquals(result.includes('--expect="alt-enter"'), true);
+    });
+
+    it("handles undefined and null correctly", () => {
+      const options: FzfOptions = {
+        "--undefined-value": undefined as unknown as string,
+        "--null-value": null as unknown as string,
+      };
+
+      const result = fzfOptionsToString(options);
+
+      // undefined and null should just output the key
+      assertEquals(
+        result,
+        '--expect="alt-enter" --undefined-value --null-value',
+      );
+    });
+  });
+});

--- a/test/fzf_option_convert_test.ts
+++ b/test/fzf_option_convert_test.ts
@@ -21,8 +21,8 @@ describe("fzf option convert", () => {
 
     it("handles number values correctly", () => {
       const options: FzfOptions = {
-        "--header-lines": 2 as unknown as string,
-        "--height": 80 as unknown as string,
+        "--header-lines": 2,
+        "--height": 80,
       };
 
       const result = fzfOptionsToString(options);
@@ -35,7 +35,7 @@ describe("fzf option convert", () => {
       const options: FzfOptions = {
         "--multi": true,
         "--ansi": true,
-        "--disabled": false as unknown as true,
+        "--disabled": false,
       };
 
       const result = fzfOptionsToString(options);
@@ -46,7 +46,7 @@ describe("fzf option convert", () => {
     it("handles mixed types", () => {
       const options: FzfOptions = {
         "--header": "Results",
-        "--header-lines": 2 as unknown as string,
+        "--header-lines": 2,
         "--multi": true,
         "--preview": "echo {}",
       };
@@ -63,8 +63,8 @@ describe("fzf option convert", () => {
 
     it("handles undefined and null correctly", () => {
       const options: FzfOptions = {
-        "--undefined-value": undefined as unknown as string,
-        "--null-value": null as unknown as string,
+        "--undefined-value": undefined,
+        "--null-value": null,
       };
 
       const result = fzfOptionsToString(options);


### PR DESCRIPTION
## Summary
- Fix crash when using numeric values in fzf options (e.g., `--header-lines: 2`)
- Add comprehensive tests for various option types

## Problem
Previously, when using numeric values in YAML configuration like:
```yaml
--header-lines: 2
```
The application would crash because `generalOptionsToArray` only handled string values.

## Solution
- Added handling for `number` type in the option conversion
- Added filtering to remove `undefined` values from boolean false cases
- Added comprehensive tests covering string, number, boolean, and edge cases

## Test plan
- [x] Added unit tests for various option types
- [x] Manually tested with numeric `--header-lines` option
- [x] All CI checks pass (type-check, lint, test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric and boolean option values to ensure correct formatting and filtering of options.

* **Tests**
  * Added comprehensive tests to verify correct conversion of options to command-line strings, covering various value types and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->