### PR TITLE
feat(config): support multi-file configs from ZENO_HOME and XDG

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,12 @@ See: https://github.com/yuki-yano/zeno.zsh/blob/main/src/completion/source/git.t
 
 The configuration file is searched from the following.
 
-- `$ZENO_HOME/config.yml`
-- `$XDG_CONFIG_HOME/zeno/config.yml` or `~/.config/zeno/config.yml`
-- Find `.../zeno/config.yml` from each in `$XDG_CONFIG_DIRS`
+- If `$ZENO_HOME` is a directory, all `*.yml`/`*.yaml` directly under it are loaded and merged (A→Z).
+- Otherwise, search XDG config directories in order and if `zeno/` exists, load and merge all `zeno/*.yml`/`*.yaml` in the first directory that contains any.
+- Fallbacks for backward compatibility:
+  - `$ZENO_HOME/config.yml`
+  - `$XDG_CONFIG_HOME/zeno/config.yml` or `~/.config/zeno/config.yml`
+  - Find `.../zeno/config.yml` from each in `$XDG_CONFIG_DIRS`
 
 ### Example
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,9 +1,5 @@
 import { exists, path, xdg, yamlParse } from "../deps.ts";
-import type {
-  Settings,
-  Snippet,
-  UserCompletionSource,
-} from "../type/settings.ts";
+import type { Settings } from "../type/settings.ts";
 import { getEnv } from "./env.ts";
 
 export const DEFAULT_CONFIG_FILENAME = "config.yml";

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -2,7 +2,6 @@ import { exists, path, xdg } from "../deps.ts";
 import type { Settings } from "../type/settings.ts";
 import {
   DEFAULT_APP_DIR,
-  findConfigFilePath,
   findYamlFilesInDir,
   getDefaultSettings,
   loadConfigFile,

--- a/test/config/manager_multi_yaml_test.ts
+++ b/test/config/manager_multi_yaml_test.ts
@@ -136,11 +136,14 @@ snippets:
     Deno.env.set("XDG_CONFIG_HOME", xdgHome);
 
     const cfg = path.join(appDir, "config.yml");
-    Deno.writeTextFileSync(cfg, `
+    Deno.writeTextFileSync(
+      cfg,
+      `
 snippets:
   - keyword: xdg
     snippet: single
-`);
+`,
+    );
 
     const settings = await getSettings();
     assertEquals(settings.snippets.map((s) => s.keyword), ["xdg"]);

--- a/test/config/manager_multi_yaml_test.ts
+++ b/test/config/manager_multi_yaml_test.ts
@@ -23,6 +23,15 @@ describe("config manager - multi YAML loading", () => {
   it("merges all YAML files under $ZENO_HOME (non-recursive)", async () => {
     const tempDir = context.getTempDir();
 
+    // Isolate XDG so local environment won't interfere
+    Deno.env.set(
+      "XDG_CONFIG_DIRS",
+      [path.join(tempDir, "xdg1"), path.join(tempDir, "xdg2")].join(
+        path.DELIMITER,
+      ),
+    );
+    Deno.env.set("XDG_CONFIG_HOME", path.join(tempDir, "xdg-home-empty"));
+
     // Prepare $ZENO_HOME with two YAML files
     const zenoHome = path.join(tempDir, "zeno-home");
     Deno.mkdirSync(zenoHome, { recursive: true });
@@ -68,6 +77,14 @@ completions:
     // Ensure $ZENO_HOME does not point to a directory with YAMLs
     Deno.env.delete("ZENO_HOME");
 
+    // Isolate XDG directories
+    Deno.env.set(
+      "XDG_CONFIG_DIRS",
+      [path.join(tempDir, "xdg1"), path.join(tempDir, "xdg2")].join(
+        path.DELIMITER,
+      ),
+    );
+
     // Set XDG_CONFIG_HOME and place YAMLs under zeno/
     const xdgHome = path.join(tempDir, "xdg-home");
     const appDir = path.join(xdgHome, "zeno");
@@ -103,6 +120,15 @@ completions:
   it("falls back to $ZENO_HOME/config.yml when no YAML groups exist", async () => {
     const tempDir = context.getTempDir();
 
+    // Isolate XDG so it doesn't pick up real config
+    Deno.env.set(
+      "XDG_CONFIG_DIRS",
+      [path.join(tempDir, "xdg1"), path.join(tempDir, "xdg2")].join(
+        path.DELIMITER,
+      ),
+    );
+    Deno.env.set("XDG_CONFIG_HOME", path.join(tempDir, "xdg-home-empty"));
+
     // Prepare $ZENO_HOME with a single config.yml
     const zenoHome = path.join(tempDir, "zeno-home2");
     Deno.mkdirSync(zenoHome, { recursive: true });
@@ -134,6 +160,14 @@ snippets:
     const appDir = path.join(xdgHome, "zeno");
     Deno.mkdirSync(appDir, { recursive: true });
     Deno.env.set("XDG_CONFIG_HOME", xdgHome);
+
+    // Isolate XDG directories to avoid real system dirs
+    Deno.env.set(
+      "XDG_CONFIG_DIRS",
+      [path.join(tempDir, "xdg1"), path.join(tempDir, "xdg2")].join(
+        path.DELIMITER,
+      ),
+    );
 
     const cfg = path.join(appDir, "config.yml");
     Deno.writeTextFileSync(

--- a/test/config/manager_multi_yaml_test.ts
+++ b/test/config/manager_multi_yaml_test.ts
@@ -1,0 +1,148 @@
+import {
+  afterEach,
+  assertEquals,
+  beforeEach,
+  describe,
+  it,
+  path,
+} from "../deps.ts";
+import { Helper } from "../helpers.ts";
+import { clearCache, getSettings } from "../../src/settings.ts";
+
+describe("config manager - multi YAML loading", () => {
+  const context = new Helper();
+
+  beforeEach(() => {
+    clearCache();
+  });
+
+  afterEach(() => {
+    context.restoreAll();
+  });
+
+  it("merges all YAML files under $ZENO_HOME (non-recursive)", async () => {
+    const tempDir = context.getTempDir();
+
+    // Prepare $ZENO_HOME with two YAML files
+    const zenoHome = path.join(tempDir, "zeno-home");
+    Deno.mkdirSync(zenoHome, { recursive: true });
+    Deno.env.set("ZENO_HOME", zenoHome);
+
+    const aYml = path.join(zenoHome, "a.yml");
+    const bYaml = path.join(zenoHome, "b.yaml");
+    Deno.writeTextFileSync(
+      aYml,
+      `
+snippets:
+  - keyword: a
+    snippet: from-a
+completions:
+  - name: comp-a
+    patterns: ["^a "]
+    sourceCommand: echo a
+    callback: echo a {}
+`,
+    );
+    Deno.writeTextFileSync(
+      bYaml,
+      `
+snippets:
+  - keyword: b
+    snippet: from-b
+completions:
+  - name: comp-b
+    patterns: ["^b "]
+    sourceCommand: echo b
+    callback: echo b {}
+`,
+    );
+
+    const settings = await getSettings();
+    assertEquals(settings.snippets.map((s) => s.keyword), ["a", "b"]);
+    assertEquals(settings.completions.map((c) => c.name), ["comp-a", "comp-b"]);
+  });
+
+  it("merges YAML files under first XDG config dir's zeno/ when $ZENO_HOME has none", async () => {
+    const tempDir = context.getTempDir();
+
+    // Ensure $ZENO_HOME does not point to a directory with YAMLs
+    Deno.env.delete("ZENO_HOME");
+
+    // Set XDG_CONFIG_HOME and place YAMLs under zeno/
+    const xdgHome = path.join(tempDir, "xdg-home");
+    const appDir = path.join(xdgHome, "zeno");
+    Deno.mkdirSync(appDir, { recursive: true });
+    Deno.env.set("XDG_CONFIG_HOME", xdgHome);
+
+    const aYml = path.join(appDir, "01.yml");
+    const bYaml = path.join(appDir, "02.yaml");
+    Deno.writeTextFileSync(
+      aYml,
+      `
+snippets:
+  - keyword: x
+    snippet: from-x
+`,
+    );
+    Deno.writeTextFileSync(
+      bYaml,
+      `
+completions:
+  - name: comp-y
+    patterns: ["^y "]
+    sourceCommand: echo y
+    callback: echo y {}
+`,
+    );
+
+    const settings = await getSettings();
+    assertEquals(settings.snippets.map((s) => s.keyword), ["x"]);
+    assertEquals(settings.completions.map((c) => c.name), ["comp-y"]);
+  });
+
+  it("falls back to $ZENO_HOME/config.yml when no YAML groups exist", async () => {
+    const tempDir = context.getTempDir();
+
+    // Prepare $ZENO_HOME with a single config.yml
+    const zenoHome = path.join(tempDir, "zeno-home2");
+    Deno.mkdirSync(zenoHome, { recursive: true });
+    Deno.env.set("ZENO_HOME", zenoHome);
+    const configYml = path.join(zenoHome, "config.yml");
+    Deno.writeTextFileSync(
+      configYml,
+      `
+snippets:
+  - keyword: only
+    snippet: legacy
+`,
+    );
+
+    const settings = await getSettings();
+    assertEquals(settings.snippets.map((s) => s.keyword), ["only"]);
+  });
+
+  it("falls back to XDG zeno/config.yml when $ZENO_HOME has no YAML and no config.yml", async () => {
+    const tempDir = context.getTempDir();
+
+    // Point $ZENO_HOME to an empty dir without YAML/config.yml
+    const emptyHome = path.join(tempDir, "empty-home");
+    Deno.mkdirSync(emptyHome, { recursive: true });
+    Deno.env.set("ZENO_HOME", emptyHome);
+
+    // Provide XDG config with single-file legacy config
+    const xdgHome = path.join(tempDir, "xdg-home-single");
+    const appDir = path.join(xdgHome, "zeno");
+    Deno.mkdirSync(appDir, { recursive: true });
+    Deno.env.set("XDG_CONFIG_HOME", xdgHome);
+
+    const cfg = path.join(appDir, "config.yml");
+    Deno.writeTextFileSync(cfg, `
+snippets:
+  - keyword: xdg
+    snippet: single
+`);
+
+    const settings = await getSettings();
+    assertEquals(settings.snippets.map((s) => s.keyword), ["xdg"]);
+  });
+});


### PR DESCRIPTION
## Summary
Add multi-file configuration loading. If multiple YAML files are present, the settings are merged in a predictable order without breaking the existing single-file workflow.

## Motivation
Users want to split large `config.yml` files into smaller logical files (e.g., one per topic) while keeping compatibility with current setups.

## Behavior
- Directory scan (non-recursive) and merge in filename ascending order (A→Z).
- Arrays are concatenated as-is (no de-duplication):
  - `snippets`
  - `completions`
- If nothing is found at a step, proceed to the next step.

### Load Order (highest → lowest)
1. `$ZENO_HOME/*.yml` or `*.yaml` (when `$ZENO_HOME` is a directory)
2. The first XDG config directory (from `xdg.configDirs()`) that contains `zeno/*.yml|*.yaml`
3. Fallbacks for backward compatibility:
   - `$ZENO_HOME/config.yml`
   - `.../zeno/config.yml` in XDG config directories

## Implementation
- `src/config/loader.ts`
  - Add `findYamlFilesInDir(dir)` to list YAML files directly under a directory.
  - Add `loadConfigFiles(paths)` to merge multiple config files.
  - Export `DEFAULT_APP_DIR` for reuse.
- `src/config/manager.ts`
  - Implement the search/merge order described above.
  - Keep legacy single-file fallbacks intact.
- `README.md`
  - Document the new search order and merge behavior.
- Tests: `test/config/manager_multi_yaml_test.ts`
  - `$ZENO_HOME` directory merges multiple YAML files.
  - XDG `zeno/*.yml|*.yaml` merge when `$ZENO_HOME` provides none.
  - Fallback to `$ZENO_HOME/config.yml`.
  - Fallback to XDG `zeno/config.yml` when `$ZENO_HOME` has neither YAML nor `config.yml`.

## Backward Compatibility
- No breaking changes. Existing single-file configs continue to work.

## Limitations / Future Work
- Non-recursive directory scan.
- Only the first XDG directory with YAML is merged (not all). We can extend to merge across all XDG dirs or add de-duplication/options if needed.

## Migration Notes
- Optional: Move your monolithic config to several YAML files under `$ZENO_HOME/` or `$XDG_CONFIG_HOME/zeno/` (or any directory in `XDG_CONFIG_DIRS`). The loader will pick them up and merge automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Hierarchical configuration discovery that loads and deterministically merges multiple YAML files (A→Z). Respects ZENO_HOME as a directory and searches XDG config dirs; preserves legacy single-file fallbacks.
  - Improved error messages during config scanning and loading.

- Documentation
  - README updated to describe the new discovery, merge behavior, and fallback order.

- Tests
  - Added tests validating multi-file merging and legacy fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->