### PR TITLE
feat: Add JSR package publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+name: Publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish package
+        run: npx jsr publish

--- a/deno.json
+++ b/deno.json
@@ -1,3 +1,11 @@
 {
-  "lock": false
+  "lock": false,
+  "name": "@yuki-yano/zeno",
+  "version": "0.1.0",
+  "license": "MIT",
+  "exports": "./src/mod.ts",
+  "publish": {
+    "include": ["src/**/*.ts", "README.md", "LICENSE"],
+    "exclude": ["src/**/*_test.ts", "test/**", "shells/**"]
+  }
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,0 +1,26 @@
+/**
+ * @module
+ * Zeno configuration types for TypeScript config files
+ *
+ * @example
+ * ```typescript
+ * import type { Settings } from "jsr:@yuki-yano/zeno";
+ *
+ * export default {
+ *   snippets: [
+ *     {
+ *       name: "git status",
+ *       keyword: "gs",
+ *       snippet: "git status --short --branch"
+ *     }
+ *   ],
+ *   completions: []
+ * } satisfies Settings;
+ * ```
+ */
+
+export type {
+  Settings,
+  Snippet,
+  UserCompletionSource,
+} from "./type/settings.ts";

--- a/test/app-helpers_test.ts
+++ b/test/app-helpers_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "./deps.ts";
-import { write } from "../src/text-writer.ts";
+import type { write } from "../src/text-writer.ts";
 import {
   handleNullableResult,
   handleStatusResult,

--- a/test/settings_test.ts
+++ b/test/settings_test.ts
@@ -15,7 +15,7 @@ import {
   loadConfigFile,
   setSettings,
 } from "../src/settings.ts";
-import { Snippet, UserCompletionSource } from "../src/type/settings.ts";
+import type { Snippet, UserCompletionSource } from "../src/type/settings.ts";
 
 describe("settings", () => {
   const context = new Helper();


### PR DESCRIPTION
## Summary
- JSRパッケージとして型定義を公開できるようにしました
- ユーザーがTypeScript設定ファイルを書く際に型安全に記述できるようになります

## Changes
- GitHub Actions workflow (`.github/workflows/publish.yml`)を追加
  - mainブランチへのpush時に自動的にJSRに公開
- パッケージエントリポイント (`src/mod.ts`)を作成
  - Settings, Snippet, UserCompletionSource型をエクスポート
- `deno.json`にJSRパッケージ設定を追加
  - パッケージ名: `@yuki-yano/zeno`
  - バージョン: `0.1.0`
- type-onlyインポートを修正

## Usage Example
ユーザーは以下のように型定義を利用できます：

```typescript
import type { Settings } from "jsr:@yuki-yano/zeno";

export default {
  snippets: [
    {
      name: "git status",
      keyword: "gs",
      snippet: "git status --short --branch"
    }
  ],
  completions: []
} satisfies Settings;
```

## Notes
- JSRパッケージは https://jsr.io/@yuki-yano/zeno で公開されます
- mainブランチにマージ後、自動的に公開されます