### PR TITLE
fix: avoid prompt-leading-character from disappearing

### DIFF
--- a/shells/zsh/widgets/zeno-ghq-cd
+++ b/shells/zsh/widgets/zeno-ghq-cd
@@ -18,10 +18,12 @@ options+=" --bind ctrl-d:preview-page-down,ctrl-u:preview-page-up"
 dir=$(echo "${(F)out}" | eval "${ZENO_FZF_COMMAND} $options")
 
 if [[ -z $dir ]]; then
+  zle reset-prompt
   return 1
 fi
 
 BUFFER="cd ${dir// /\\ }"
+zle reset-prompt
 zle accept-line
 
 if [[ -n $TMUX ]]; then


### PR DESCRIPTION
When running `fzf-ghq-cd`, the leading character of the prompt was disappearing.
This has been fixed by `reset-prompt` before executing `accept-line`

Before:


https://github.com/user-attachments/assets/c338e378-670a-43ac-9533-e0eb0bd47172



After:


https://github.com/user-attachments/assets/17c3586f-a389-40dc-b633-96f9d6cbd7f4




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced prompt refresh behavior in the directory navigation widget to ensure consistent terminal display during directory changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->