### PR TITLE
fix: preserve empty strings in fzf-config output using null delimiter

### DIFF
--- a/shells/zsh/widgets/zeno-smart-history-selection
+++ b/shells/zsh/widgets/zeno-smart-history-selection
@@ -52,11 +52,12 @@ else
   local fzf_config_raw
   if fzf_config_raw=$("$zeno_client" history fzf-config 2>/dev/null); then
     local -a fzf_config_lines
-    fzf_config_lines=(${(f)fzf_config_raw})
+    # Use null character delimiter to preserve empty strings
+    fzf_config_lines=("${(@ps:\0:)fzf_config_raw}")
     if [[ ${fzf_config_lines[1]-} == success ]]; then
       config_fzf_command=${fzf_config_lines[2]-}
       if [[ ${#fzf_config_lines[@]} -ge 3 && -n ${fzf_config_lines[3]} ]]; then
-        config_fzf_options=(${(z)fzf_config_lines[3]})
+        config_fzf_options=("${(@z)fzf_config_lines[3]}")
       fi
       if [[ ${#fzf_config_lines[@]} -ge 4 && -n ${fzf_config_lines[4]} ]]; then
         preview_toggle_key=${fzf_config_lines[4]}

--- a/src/history/fzf-config-command.ts
+++ b/src/history/fzf-config-command.ts
@@ -16,13 +16,14 @@ export const createHistoryFzfConfigCommand = (
         const settings = await deps.loadHistorySettings();
         const command = settings.fzfCommand ?? "";
         const options = settings.fzfOptions?.join(" ") ?? "";
-        await writeResult(
-          writer.write.bind(writer),
+        // Use null character delimiter to preserve empty strings
+        const data = [
           "success",
           command,
           options,
           settings.keymap.togglePreview,
-        );
+        ].join("\0");
+        await writer.write({ format: "%s\n", text: data });
       } catch (error) {
         await writeResult(
           writer.write.bind(writer),

--- a/test/history/history_fzf_config_command_test.ts
+++ b/test/history/history_fzf_config_command_test.ts
@@ -38,10 +38,7 @@ describe("history-fzf-config command", () => {
     });
 
     assertEquals(writer.lines, [
-      "success",
-      "fzf-tmux",
-      "-p 80%",
-      "alt-p",
+      "success\0fzf-tmux\0-p 80%\0alt-p",
     ]);
   });
 
@@ -67,7 +64,7 @@ describe("history-fzf-config command", () => {
       writer,
     });
 
-    assertEquals(writer.lines, ["success", "", "", "?"]);
+    assertEquals(writer.lines, ["success\0\0\0?"]);
   });
 
   it("reports errors", async () => {


### PR DESCRIPTION
When `history.fzfCommand` was empty in the config, the output used newline delimiters which caused Zsh to drop empty lines during array splitting.
This resulted in the preview toggle key (`?`) being incorrectly parsed as the fzf command, causing `"command not found: ?"` errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration field parsing in history selection to correctly preserve and properly handle empty configuration values.
  * Enhanced extraction and application of history selection settings to ensure reliable and consistent operation across various configuration scenarios.
  * Fixed potential issues where certain configuration options might not have been correctly processed when fields contained empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->