### PR TITLE
fix(snippet): escape invisible characters in snippet list display

### DIFF
--- a/src/snippet/snippet-list.ts
+++ b/src/snippet/snippet-list.ts
@@ -11,6 +11,14 @@ export const snippetListOptions = () => {
   return `${DEFAULT_SNIPPET_LIST_OPTION.join(" ")}`;
 };
 
+const escapeInvisibleChars = (text: string): string => {
+  return text
+    .replace(/\\/g, "\\\\") // escape backslash first
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+};
+
 export const snippetList = async () => {
   const loadedSnippets = await loadSnippets();
 
@@ -26,7 +34,11 @@ export const snippetList = async () => {
   const lineFormat = `%-${nameWidth}s  %s`;
 
   const nameAndSnippet = snippets.map(({ snippet, name }) =>
-    sprintf(lineFormat, name?.length ? `${name}:` : "", snippet)
+    sprintf(
+      lineFormat,
+      name?.length ? `${name}:` : "",
+      escapeInvisibleChars(snippet),
+    )
   );
 
   return nameAndSnippet;


### PR DESCRIPTION
Ensure snippet list displays readable escaped sequences instead of raw invisible characters

Sample config:

```yml
snippets:
  - name: list path
    keyword: path
    snippet: echo $PATH | tr ':' '\n'

  - name: list fpath
    keyword: fpath
    snippet: echo $FPATH | tr ':' '\n'
```

Before:

<img width="557" height="409" alt="before" src="https://github.com/user-attachments/assets/7b81f383-8ddf-46ca-9947-6d341ec826fa" />


After:

<img width="557" height="409" alt="after" src="https://github.com/user-attachments/assets/31a492bb-5390-4f63-b79c-de17e381e028" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invisible characters (backslashes, newlines, carriage returns, tabs) so snippets render safely and display correctly.
  * Ensured snippet formatting and width calculations use the escaped snippet text while preserving existing single-line validation and listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->