### PR TITLE
fix: disable multi-selection in fzf widgets

### DIFF
--- a/shells/fish/functions/zeno-ghq-cd.fish
+++ b/shells/fish/functions/zeno-ghq-cd.fish
@@ -19,6 +19,7 @@ function zeno-ghq-cd --description "Select and change to a ghq repository direct
     end
     set options $options "--prompt='Project >' --preview 'cat \$(eval echo {})/README.md'"
     set options $options "--bind ctrl-d:preview-page-down,ctrl-u:preview-page-up"
+    set options $options "--no-multi"
     
     # Select directory with fzf
     set -l selected_dir (printf '%s\n' $repos | eval "$ZENO_FZF_COMMAND $options")

--- a/shells/fish/functions/zeno-history-selection.fish
+++ b/shells/fish/functions/zeno-history-selection.fish
@@ -9,7 +9,7 @@ function zeno-history-selection --description "Select a command from history"
     set -l current_buffer (commandline -b)
     
     # Add fzf options
-    set options $options "--no-sort --exact --query='$current_buffer' --prompt='History> '"
+    set options $options "--no-sort --exact --no-multi --query='$current_buffer' --prompt='History> '"
     
     # Check if bat is available for preview
     if command -q bat

--- a/shells/zsh/widgets/zeno-ghq-cd
+++ b/shells/zsh/widgets/zeno-ghq-cd
@@ -15,6 +15,7 @@ fi
 options=${ZENO_ENABLE_FZF_TMUX:+${ZENO_FZF_TMUX_OPTIONS}}
 options+=" --prompt='Project >' --preview 'cat \$(eval echo {})/README.md'"
 options+=" --bind ctrl-d:preview-page-down,ctrl-u:preview-page-up"
+options+=" --no-multi"
 dir=$(echo "${(F)out}" | eval "${ZENO_FZF_COMMAND} $options")
 
 if [[ -z $dir ]]; then

--- a/shells/zsh/widgets/zeno-history-selection
+++ b/shells/zsh/widgets/zeno-history-selection
@@ -32,6 +32,7 @@ fi
 fzf_args+=(
   --no-sort
   --exact
+  --no-multi
   "--query=$LBUFFER"
   "--prompt=History> "
   "--with-nth=2.."

--- a/shells/zsh/widgets/zeno-smart-history-selection
+++ b/shells/zsh/widgets/zeno-smart-history-selection
@@ -180,6 +180,7 @@ fzf_opts=(
   "--with-nth=2..6"
   "$fzf_delimiter_opt"
   "--ansi"
+  "--no-multi"
   "--header-lines=1"
   "--bind"
   "start:reload(:)+reload(${scope_cmd_str})"

--- a/src/snippet/snippet-list.ts
+++ b/src/snippet/snippet-list.ts
@@ -5,6 +5,7 @@ const DEFAULT_SNIPPET_LIST_OPTION = [
   "--delimiter=':'",
   "--prompt='Snippet> '",
   "--height='80%'",
+  "--no-multi",
 ];
 
 export const snippetListOptions = () => {


### PR DESCRIPTION
Add `--no-multi` option to prevent unintended multiple selections when `$FZF_DEFAULT_OPTS` has `--multi` option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Repository directory selection now enforces single-item selection
  * History selection now enforces single-item selection  
  * Snippet list selection now enforces single-item selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->